### PR TITLE
Fix conflict with Sodium 1.20

### DIFF
--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/sodium/MixinChunkTracker.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/sodium/MixinChunkTracker.java
@@ -18,7 +18,7 @@
 package de.florianmichael.viafabricplus.injection.mixin.fixes.sodium;
 
 import de.florianmichael.viafabricplus.base.settings.groups.VisualSettings;
-import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
+import it.unimi.dsi.fastutil.longs.Long2BooleanOpenHashMap;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
@@ -28,10 +28,10 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 @Mixin(targets = "me.jellysquid.mods.sodium.client.render.chunk.ChunkTracker", remap = false)
 public abstract class MixinChunkTracker {
 
-    @Redirect(method = "recalculateChunks", at = @At(value = "INVOKE", target = "Lit/unimi/dsi/fastutil/longs/Long2IntOpenHashMap;get(J)I"))
-    private int modifyRenderCondition(Long2IntOpenHashMap instance, long k) {
+    @Redirect(method = "recalculateChunks", at = @At(value = "INVOKE", target = "Lit/unimi/dsi/fastutil/longs/Long2BooleanOpenHashMap;get(J)Z"))
+    private boolean modifyRenderCondition(Long2BooleanOpenHashMap instance, long k) {
         if (VisualSettings.INSTANCE.fixSodiumChunkRendering.getValue()) {
-            return instance.getOrDefault(k, -1);
+            return instance.getOrDefault(k, false);
         }
 
         return instance.get(k);


### PR DESCRIPTION
The Sodium developers chose to change the map their ChunkTracker uses from a Long2IntOpenHashMap to a Long2BooleanOpenHashMap. This conflicts with our mixin, so I modified the mixin a small amount to use the new type.