### PR TITLE
Reimplement repetitive 1.14.3 START_DESTROY_BLOCK calls for same block breaking

### DIFF
--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/MixinClientPlayerInteractionManager.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/MixinClientPlayerInteractionManager.java
@@ -82,7 +82,7 @@ public abstract class MixinClientPlayerInteractionManager {
     @Inject(method = "breakBlock", at = @At("TAIL"))
     public void resetBlockBreaking(BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
         if (ProtocolHack.getTargetVersion().isOlderThanOrEqualTo(VersionEnum.r1_14_3)) {
-            this.currentBreakingPos = new BlockPos(this.currentBreakingPos.getX(), this.client.world.getBottomY() - 1, this.currentBreakingPos.getZ());
+            this.currentBreakingPos = new BlockPos(this.currentBreakingPos.getX(), -1, this.currentBreakingPos.getZ());
         }
     }
 

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/MixinClientPlayerInteractionManager.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/MixinClientPlayerInteractionManager.java
@@ -44,6 +44,7 @@ import net.minecraft.screen.slot.SlotActionType;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -69,11 +70,21 @@ public abstract class MixinClientPlayerInteractionManager {
     @Final
     private ClientPlayNetworkHandler networkHandler;
 
+    @Shadow
+    private BlockPos currentBreakingPos;
+
     @Unique
     private ItemStack viafabricplus_oldCursorStack;
 
     @Unique
     private List<ItemStack> viafabricplus_oldItems;
+
+    @Inject(method = "breakBlock", at = @At("TAIL"))
+    public void resetBlockBreaking(BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
+        if (ProtocolHack.getTargetVersion().isOlderThanOrEqualTo(VersionEnum.r1_14_3)) {
+            this.currentBreakingPos = new BlockPos(this.currentBreakingPos.getX(), this.client.world.getBottomY() - 1, this.currentBreakingPos.getZ());
+        }
+    }
 
     @Inject(method = "attackEntity", at = @At("HEAD"))
     private void injectAttackEntity(PlayerEntity player, Entity target, CallbackInfo ci) {


### PR DESCRIPTION
This will fix false-positives (caused by different client version) of speed mining for anti-cheats like NCP.
1.14.3 to 1.14.4 comparison: 
![image](https://github.com/ViaVersion/ViaFabricPlus/assets/6661231/21e4a62b-e85c-4cfb-9b77-9e9797e0ef76)
As 1.14.4 `currentBreakingPos` not resetting to something else on block break, none `START_DESTROY_BLOCK` packet is sent on any second break of the block that is on the same postion. This affects mining blocks in protected regions, annihilation minigames, afk player stone farms, etc.
Fixed this by setting to a position that is outside the world like old mc did it, but with taking into account custom world heights.