### PR TITLE
Update sources, Require API 0.83.0 or greater.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ViaFabricPlus is intended to replace [multiconnect](https://github.com/Earthcomp
 
 # For users
 ### Detailed instructions for use are available here [here](.github/USAGE.md)
-### If you encounter any issues, please report them on the [issue tracker](https://github.com/FlorianMichael/ViaFabricPlus/issues) or on the ViaVersion [Discord](https://discord.gg/viaversion)
+### If you encounter any issues, please report them on the [issue tracker](https://github.com/ViaVersion/ViaFabricPlus/issues) or on the ViaVersion [Discord](https://discord.gg/viaversion)
 
 ## Known incompatibilities
 - ***[ViaFabric](https://github.com/ViaVersion/ViaFabric)***
@@ -87,7 +87,7 @@ For compiling only! **You do not need to install these!**
 
 ### Setting up a Workspace
 ViaFabricPlus uses Gradle, to make sure that it is installed properly you can check [Gradle's website](https://gradle.org/install/).
-1. Clone the repository using `git clone https://github.com/FlorianMichael/ViaFabricPlus`.
+1. Clone the repository using `git clone https://github.com/ViaVersion/ViaFabricPlus`.
 2. CD into the local repository.
 3. Run `./gradlew genSources`.
 4. Open the folder as a Gradle project in your preferred IDE.

--- a/src/main/resources/assets/viafabricplus/lang/cs_cz.json
+++ b/src/main/resources/assets/viafabricplus/lang/cs_cz.json
@@ -55,7 +55,7 @@
   "visual.viafabricplus.sodium": "Opravit renderer chunků v Sodium módu",
 
   "bedrocklogin.viafabricplus.text": "Váš webový prohlížeč by se měl spustit.\nProsím zadejte tento Kód: %s\nZavření této obrazovky zruší tento proces!",
-  "bedrocklogin.viafabricplus.error": "Nastala chyba. Podívejte se do souboru latest.log pro více informací,\nprosím nahlašte tuto chybu zde (nejlépe v angličtině): \nhttps://github.com/FlorianMichael/ViaFabricPlus/issues",
+  "bedrocklogin.viafabricplus.error": "Nastala chyba. Podívejte se do souboru latest.log pro více informací,\nprosím nahlašte tuto chybu zde (nejlépe v angličtině): \nhttps://github.com/ViaVersion/ViaFabricPlus/issues",
 
   "forceversion.viafabricplus.title": "Prosím zvolte verzi s kterou se bude server pingovat/připojovat",
 

--- a/src/main/resources/assets/viafabricplus/lang/de_de.json
+++ b/src/main/resources/assets/viafabricplus/lang/de_de.json
@@ -45,7 +45,7 @@
   "visual.viafabricplus.walkanimation": "Alte Lauf-Animation",
 
   "bedrocklogin.viafabricplus.text": "Dein Browser sollte sich jetzt geöffnet haben.\nBitte gib den folgenden Code ein: %s\nWenn du diesen Bildschirm schließt, wird der Prozess abgebrochen.",
-  "bedrocklogin.viafabricplus.error": "Ein Fehler ist aufgetreten! In der latest.log sind genauere Informationen;\bitte Melde den Fehler unter: \nhttps://github.com/FlorianMichael/ViaFabricPlus/issues",
+  "bedrocklogin.viafabricplus.error": "Ein Fehler ist aufgetreten! In der latest.log sind genauere Informationen;\bitte Melde den Fehler unter: \nhttps://github.com/ViaVersion/ViaFabricPlus/issues",
 
   "forceversion.viafabricplus.title": "Bitte wähle die Version, die beim Verbinden mit dem Server verwendet werden soll"
 }

--- a/src/main/resources/assets/viafabricplus/lang/en_us.json
+++ b/src/main/resources/assets/viafabricplus/lang/en_us.json
@@ -69,7 +69,7 @@
   "visual.viafabricplus.sodium": "Fix Sodium Chunk renderer",
 
   "bedrocklogin.viafabricplus.text": "Your browser should have opened.\nPlease enter the following Code: %s\nClosing this screen will cancel the process!",
-  "bedrocklogin.viafabricplus.error": "An error has occurred! See the latest.log for more information,\nplease report the bug at: \nhttps://github.com/FlorianMichael/ViaFabricPlus/issues",
+  "bedrocklogin.viafabricplus.error": "An error has occurred! See the latest.log for more information,\nplease report the bug at: \nhttps://github.com/ViaVersion/ViaFabricPlus/issues",
 
   "forceversion.viafabricplus.title": "Please select the version with which the server should be pinged/connected",
 

--- a/src/main/resources/assets/viafabricplus/lang/fi_fi.json
+++ b/src/main/resources/assets/viafabricplus/lang/fi_fi.json
@@ -60,7 +60,7 @@
   "visual.viafabricplus.sodium": "Korjaa Sodium:in chunk-renderöijä",
 
   "bedrocklogin.viafabricplus.text": "Selaimesi taisi aueta.\nKirjoita seuraava koodi: %s\nNäytön sulkeminen aiheuttaa prosessin loppumisen!",
-  "bedrocklogin.viafabricplus.error": "Virhe tapahtui! Katso latest.log lisätietoja varten,\nole hyvä, ja raportoi bugi täällä: \nhttps://github.com/FlorianMichael/ViaFabricPlus/issues",
+  "bedrocklogin.viafabricplus.error": "Virhe tapahtui! Katso latest.log lisätietoja varten,\nole hyvä, ja raportoi bugi täällä: \nhttps://github.com/ViaVersion/ViaFabricPlus/issues",
 
   "forceversion.viafabricplus.title": "Ole hyvä ja valitse versio, jolla palvelimelle pitäisi liittyä",
 

--- a/src/main/resources/assets/viafabricplus/lang/fr_fr.json
+++ b/src/main/resources/assets/viafabricplus/lang/fr_fr.json
@@ -58,7 +58,7 @@
   "visual.viafabricplus.sodium": "Corriger le rendu de chunk de Sodium",
 
   "bedrocklogin.viafabricplus.text": "Votre navigateur devrait s'être ouvert. Veuillez entrer le code suivant: %s. Fermer cette fenêtre annulera le processus!",
-  "bedrocklogin.viafabricplus.error": "Une erreur s'est produite ! Veuillez consulter latest.log pour plus d'informations. Veuillez signaler le bogue à l'adresse : \nhttps://github.com/FlorianMichael/ViaFabricPlus/issues",
+  "bedrocklogin.viafabricplus.error": "Une erreur s'est produite ! Veuillez consulter latest.log pour plus d'informations. Veuillez signaler le bogue à l'adresse : \nhttps://github.com/ViaVersion/ViaFabricPlus/issues",
 
   "forceversion.viafabricplus.title": "Veuillez sélectionner la version avec laquelle le serveur doit être pingé/connecté",
 

--- a/src/main/resources/assets/viafabricplus/lang/hu_hu.json
+++ b/src/main/resources/assets/viafabricplus/lang/hu_hu.json
@@ -58,7 +58,7 @@
     "visual.viafabricplus.sodium": "Sodium Chunk renderelő megjavítása",
   
     "bedrocklogin.viafabricplus.text": "A böngésződnek meg kellett volna nyílnia.\nKérlek írd be a következő kódot: %s\nEzen képernyő bezárása leállítja a folyamatot!",
-    "bedrocklogin.viafabricplus.error": "Hiba történt! További információért lásd a latest.log-ot,\nkérlek, jelentsd a bug-ot itt: \nhttps://github.com/FlorianMichael/ViaFabricPlus/issues",
+    "bedrocklogin.viafabricplus.error": "Hiba történt! További információért lásd a latest.log-ot,\nkérlek, jelentsd a bug-ot itt: \nhttps://github.com/ViaVersion/ViaFabricPlus/issues",
   
     "forceversion.viafabricplus.title": "Kérlek, válaszd ki azt a verziót, amellyel a szervert pingelni/csatlakozni kell",
   

--- a/src/main/resources/assets/viafabricplus/lang/ja_jp.json
+++ b/src/main/resources/assets/viafabricplus/lang/ja_jp.json
@@ -51,7 +51,7 @@
   "visual.viafabricplus.sodium": "Sodiumのチャンク描画を修正",
 
   "bedrocklogin.viafabricplus.text": "ブラウザが開きました。\nブラウザに次のコードを入力してください: %s\nこの画面を閉じるとログインが中断されます。",
-  "bedrocklogin.viafabricplus.error": "エラーが発生しました! 詳細についてはlasted.logを確認してください。\nまた、下記の場所でバグを報告してください。 \nhttps://github.com/FlorianMichael/ViaFabricPlus/issues",
+  "bedrocklogin.viafabricplus.error": "エラーが発生しました! 詳細についてはlasted.logを確認してください。\nまた、下記の場所でバグを報告してください。 \nhttps://github.com/ViaVersion/ViaFabricPlus/issues",
 
   "forceversion.viafabricplus.title": "サーバーに接続するバージョンを選択",
 

--- a/src/main/resources/assets/viafabricplus/lang/lb_lu.json
+++ b/src/main/resources/assets/viafabricplus/lang/lb_lu.json
@@ -45,7 +45,7 @@
   "visual.viafabricplus.walkanimation": "Aal Laaf-Animatioun",
 
   "bedrocklogin.viafabricplus.text": "Däin Browser sollt elo opgaangen sinn.\nGeff w.e.g. den heien Code an: %s\nWann du desse Bildschirm zoumesst, gett den Prozess ofgebrach.",
-  "bedrocklogin.viafabricplus.error": "En Fehler ist opgetrieden! An der latest.log sin genauer Informatiounen;\n.e.g. Meld den Fehler enner: \nhttps://github.com/FloriUnMichael/ViaFabricPlus/issues",
+  "bedrocklogin.viafabricplus.error": "En Fehler ist opgetrieden! An der latest.log sin genauer Informatiounen;\n.e.g. Meld den Fehler enner: \nhttps://github.com/ViaVersion/ViaFabricPlus/issues",
 
   "forceversion.viafabricplus.title": "W.e.g. wähl die Versioun, die bäim Verbannen mat dem Server benotzt ginn soll"
 }

--- a/src/main/resources/assets/viafabricplus/lang/pl_pl.json
+++ b/src/main/resources/assets/viafabricplus/lang/pl_pl.json
@@ -69,7 +69,7 @@
   "visual.viafabricplus.sodium": "Napraw renderowanie chunków sodium",
 
   "bedrocklogin.viafabricplus.text": "Powinna ci się otworzyć przeglądarka.\nProszę, wpisz ten kod: %s\nZamykanie tego ekranu będzie anulowało proces!",
-  "bedrocklogin.viafabricplus.error": "Wystąpił błąd! Zobacz latest.log po więcej informacji.\nProszę, zgłoś ten problem tutaj:\nhttps://github.com/FlorianMichael/ViaFabricPlus/issues",
+  "bedrocklogin.viafabricplus.error": "Wystąpił błąd! Zobacz latest.log po więcej informacji.\nProszę, zgłoś ten problem tutaj:\nhttps://github.com/ViaVersion/ViaFabricPlus/issues",
 
   "forceversion.viafabricplus.title": "Wybierz wersję, z którą chcesz pingować/łączyć się do serwera",
 

--- a/src/main/resources/assets/viafabricplus/lang/ru_ru.json
+++ b/src/main/resources/assets/viafabricplus/lang/ru_ru.json
@@ -66,7 +66,7 @@
   "visual.viafabricplus.sodium": "Исправить рендеринг чанков Sodium",
 
   "bedrocklogin.viafabricplus.text": "Сейчас должен открыться браузер.\nВведите следующий код: %s\nЗакрытие этого экрана приведёт к отмене процесса!",
-  "bedrocklogin.viafabricplus.error": "Произошла ошибка. Проверьте latest.log для получения дополнительных сведений.\nПожалуйста, сообщите о ней разработчику:\nhttps://github.com/FlorianMichael/ViaFabricPlus/issues",
+  "bedrocklogin.viafabricplus.error": "Произошла ошибка. Проверьте latest.log для получения дополнительных сведений.\nПожалуйста, сообщите о ней разработчику:\nhttps://github.com/ViaVersion/ViaFabricPlus/issues",
 
   "forceversion.viafabricplus.title": "Укажите версию для проверки связи с сервером и подключения к нему.",
 

--- a/src/main/resources/assets/viafabricplus/lang/th_th.json
+++ b/src/main/resources/assets/viafabricplus/lang/th_th.json
@@ -45,7 +45,7 @@
   "visual.viafabricplus.walkanimation": "ท่าทางการเดินแบบเก่า",
 
   "bedrocklogin.viafabricplus.text": "บราวเซอร์เปิดแล้ว \nกรุณาใส่โค้ด: %s\nหากปิดหน้าเกมการดำเนินการจะถูกยกเลิก",
-  "bedrocklogin.viafabricplus.error": "พบข้อผิดพลาด ดูที่ไฟล์ latest.log เพื่อดูรายละอียดเพิ่มเติม,\nกรุณาแจ้งบัคที่  \nhttps://github.com/FlorianMichael/ViaFabricPlus/issues",
+  "bedrocklogin.viafabricplus.error": "พบข้อผิดพลาด ดูที่ไฟล์ latest.log เพื่อดูรายละอียดเพิ่มเติม,\nกรุณาแจ้งบัคที่  \nhttps://github.com/ViaVersion/ViaFabricPlus/issues",
 
   "forceversion.viafabricplus.title": "โปรดเลือกเวอร์ชันที่ต้องการเชื่อมต่อ"
 }

--- a/src/main/resources/assets/viafabricplus/lang/uk_ua.json
+++ b/src/main/resources/assets/viafabricplus/lang/uk_ua.json
@@ -69,7 +69,7 @@
   "visual.viafabricplus.sodium": "Полагодити рендер чанків Содіуму",
 
   "bedrocklogin.viafabricplus.text": "Ваш браузер мав відкритися.\nБудь ласка, введіть наступний код: %s\nЯкщо закрити цей екран, процес буде скасовано!",
-  "bedrocklogin.viafabricplus.error": "Сталася помилка! Дивіться latest.log для отримання додаткової інформації,\nбудь ласка, повідомте про помилку за адресою: \nhttps://github.com/FlorianMichael/ViaFabricPlus/issues",
+  "bedrocklogin.viafabricplus.error": "Сталася помилка! Дивіться latest.log для отримання додаткової інформації,\nбудь ласка, повідомте про помилку за адресою: \nhttps://github.com/ViaVersion/ViaFabricPlus/issues",
 
   "forceversion.viafabricplus.title": "Будь ласка, виберіть версію, з якою сервер має пінгуватися/підключатися",
 

--- a/src/main/resources/assets/viafabricplus/lang/zh_cn.json
+++ b/src/main/resources/assets/viafabricplus/lang/zh_cn.json
@@ -69,7 +69,7 @@
   "visual.viafabricplus.sodium": "修复 钠/Sodium 渲染器",
 
   "bedrocklogin.viafabricplus.text": "你的浏览器现在应该打开了。\n请输入这个代码：%s\n关闭这个屏幕等于取消操作！",
-  "bedrocklogin.viafabricplus.error": "发生错误！详情请查看 latest.log\n请在这个链接反馈 BUG：\nhttps://github.com/FlorianMichael/ViaFabricPlus/issues",
+  "bedrocklogin.viafabricplus.error": "发生错误！详情请查看 latest.log\n请在这个链接反馈 BUG：\nhttps://github.com/ViaVersion/ViaFabricPlus/issues",
 
   "forceversion.viafabricplus.title": "请选择连接这个服务器要使用的版本",
 

--- a/src/main/resources/assets/viafabricplus/lang/zh_tw.json
+++ b/src/main/resources/assets/viafabricplus/lang/zh_tw.json
@@ -69,7 +69,7 @@
     "visual.viafabricplus.sodium": "修復鈉（Sodium）渲染器",
   
     "bedrocklogin.viafabricplus.text": "你的瀏覽器現在應該打開了。\n請輸入這個程式碼：%s\n關閉這個螢幕等於取消操作！",
-    "bedrocklogin.viafabricplus.error": "發生錯誤！詳情請查看 latest.log\n請在這個連結回饋 BUG：\nhttps://github.com/FlorianMichael/ViaFabricPlus/issues",
+    "bedrocklogin.viafabricplus.error": "發生錯誤！詳情請查看 latest.log\n請在這個連結回饋 BUG：\nhttps://github.com/ViaVersion/ViaFabricPlus/issues",
   
     "forceversion.viafabricplus.title": "請選擇連接這個伺服器要使用的版本",
   

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -9,9 +9,9 @@
     "FlorianMichael/EnZaXD"
   ],
   "contact": {
-    "homepage": "https://github.com/FlorianMichael/",
-    "sources": "https://github.com/FlorianMichael/ViaFabricPlus",
-    "issues": "https://github.com/FlorianMichael/ViaFabricPlus/issues"
+    "homepage": "https://github.com/ViaVersion/",
+    "sources": "https://github.com/ViaVersion/ViaFabricPlus",
+    "issues": "https://github.com/ViaVersion/ViaFabricPlus/issues"
   },
 
   "license": "GPL-v3",
@@ -27,8 +27,8 @@
   ],
   "accessWidener": "viafabricplus.accesswidener",
   "depends": {
-    "fabricloader": ">=0.14.11",
-    "fabric-api": "*",
+    "fabricloader": ">=0.14.21",
+    "fabric-api": ">=0.83.0+1.20.1",
     "minecraft": "~1.20.1",
     "java": ">=17"
   },


### PR DESCRIPTION
Replaces the old URL sources with viaversion's variants instead as this project has been long-merged into this organization,
Then fabric loader will be bumped to 0.14.21 or greater as it works best for this environment,
Finally, This mod requires 0.83.0 or greater to be used as older API versions aren't supported on 1.20.1.

EDIT: Please also ensure that the other mods also make use of the new URL sources instead of personal ones if they already exist in this organization too.