### PR TITLE
MemoryLeakFix works again over v1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ ViaFabricPlus is intended to replace [multiconnect](https://github.com/Earthcomp
 - ***[ViaFabric](https://github.com/ViaVersion/ViaFabric)***
 - ***[multiconnect](https://github.com/Earthcomputer/multiconnect)***
 - ***[krypton](https://github.com/astei/krypton)***
-- ***[MemoryLeakFix](https://github.com/fxmorin/MemoryLeakFix)***
 - ***[ReplayMod](https://www.replaymod.com/)***
 
 ## List of all clientside related fixes

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -41,7 +41,7 @@
   "breaks": {
     "viafabric": "*",
     "multiconnect": "*",
-    "memoryleakfix": "*",
+    "memoryleakfix": "<=1.1.0",
     "krypton": "<=0.2.2"
   }
 }


### PR DESCRIPTION
The issue was fixed in the latest commit