### PR TITLE
Switch to temurin, Update to 17.0.8. (Jitpack)

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,7 @@
 jdk:
-  - openjdk17
+  - temurinjdk17
 before_install:
-  - sdk install java 17.0.1-open
-  - sdk use java 17.0.1-open
+   - curl -s "https://get.sdkman.io" | bash
+   - source "$HOME/.sdkman/bin/sdkman-init.sh"
+   - sdk install java 17.0.8+7-tem
+   - sdk use java 17.0.8+7-tem


### PR DESCRIPTION
1. This PR will switch the default oracle JDK over to temurin on post-merge,
2. The JDK will be updated to 17.0.8+7 to address time-zone related bugs and that the JDK's code now defaults to C99 or later. (+ also fixes the use of C23 attributes)

*(This PR can be synced over to ViaFabric and VIAaaS)*