### PR TITLE
Return false in isForbiddenCharacter check if the font is not contained in the forbidden character map

### DIFF
--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/MixinFontStorage.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/MixinFontStorage.java
@@ -74,7 +74,9 @@ public abstract class MixinFontStorage implements IFontStorage {
             fontName = "UnihexFont";
         }
         if (fontName == null) return false;
-        return viafabricplus_forbiddenCharacters.get(fontName).contains(codePoint);
+        var forbiddenCodepoints = viafabricplus_forbiddenCharacters.get(fontName);
+        if (forbiddenCodepoints == null) return false;
+        return forbiddenCodepoints.contains(codePoint);
     }
 
     @Inject(method = "findGlyph", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/font/Font;getGlyph(I)Lnet/minecraft/client/font/Glyph;"), locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true)


### PR DESCRIPTION
Unable to test this because of the Minecraft server it was mentioned to happen on has an Anti-VPN plugin.