### PR TITLE
Prefer Text over Formatting 

### DIFF
--- a/src/main/java/de/florianmichael/viafabricplus/protocolhack/netty/viaversion/ViaFabricPlusViaDecoder.java
+++ b/src/main/java/de/florianmichael/viafabricplus/protocolhack/netty/viaversion/ViaFabricPlusViaDecoder.java
@@ -22,6 +22,7 @@ import de.florianmichael.viafabricplus.ViaFabricPlus;
 import de.florianmichael.viafabricplus.base.settings.groups.GeneralSettings;
 import de.florianmichael.viafabricplus.util.ChatUtil;
 import io.netty.channel.ChannelHandlerContext;
+import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.raphimc.vialoader.netty.ViaDecoder;
 
@@ -41,7 +42,7 @@ public class ViaFabricPlusViaDecoder extends ViaDecoder {
             } catch (Throwable t) {
                 ViaFabricPlus.LOGGER.error("Error occurred while decoding packet in ViaDecoder", t);
                 if (mode == 1) {
-                    ChatUtil.sendPrefixedMessage(Formatting.RED + "An error occurred while decoding a packet! See more details in the logs!");
+                    ChatUtil.sendPrefixedMessage(Text.literal("An error occurred while decoding a packet! See more details in the logs!").formatted(Formatting.RED));
                 }
             }
             return;

--- a/src/main/java/de/florianmichael/viafabricplus/util/ChatUtil.java
+++ b/src/main/java/de/florianmichael/viafabricplus/util/ChatUtil.java
@@ -23,16 +23,21 @@ import net.minecraft.util.Formatting;
 
 public class ChatUtil {
     public final static String PREFIX = Formatting.WHITE + "[" + Formatting.GOLD + "ViaFabricPlus" + Formatting.WHITE + "]";
+    public final static Text PREFIX_TEXT = Text.literal("[").formatted(Formatting.WHITE).append(Text.literal("ViaFabricPlus").formatted(Formatting.GOLD)).append("]");
 
     public static Text prefixText(final String message) {
         return prefixText(Text.literal(message));
     }
 
     public static Text prefixText(final Text message) {
-        return Text.literal("").append(PREFIX).append(" " + message.getString());
+        return Text.empty().append(PREFIX_TEXT).append(" ").append(message);
     }
 
     public static void sendPrefixedMessage(final String message) {
+        MinecraftClient.getInstance().inGameHud.getChatHud().addMessage(prefixText(message));
+    }
+
+    public static void sendPrefixedMessage(final Text message) {
         MinecraftClient.getInstance().inGameHud.getChatHud().addMessage(prefixText(message));
     }
 }


### PR DESCRIPTION
prefer `Text` over `Formatting` for chat/log, as Minecraft does not remove formatting from logs when using the latter. (
[example](https://github.com/ViaVersion/ViaFabricPlus/assets/32882447/bae56c26-001a-4c0b-a7a2-a557eacf37c0)
)

also `Text.empty()` > `Text.literal("")`