### PR TITLE
Set Via* to 23w41a builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.parallel=true
 minecraft_version=1.20.2
 yarn_mappings=1.20.2+build.2
 loader_version=0.14.22
-fabric_api_version=0.89.3+1.20.2
+fabric_api_version=0.90.0+1.20.2
 
 # viafabricplus
 mod_version=2.9.6-SNAPSHOT
@@ -18,8 +18,8 @@ raknet_transport_version=1.0.0.CR1-SNAPSHOT
 classic4j_version=2.0.1
 
 # viaversion (and required) libs
-viaversion_version=4.9.0-23w40a-SNAPSHOT
-viabackwards_version=4.9.0-23w40a-SNAPSHOT
+viaversion_version=4.9.0-23w41a-SNAPSHOT
+viabackwards_version=4.9.0-23w41a-SNAPSHOT
 
 vialoader_version=2.2.11-SNAPSHOT
 


### PR DESCRIPTION
Updates ViaVersion and ViaBackwards to the 23w41a builds but also updates API to 0.90.0.

*(Testing is recommended before merging)*