### PR TITLE
Gradle 8.4, G1GC, Update dependencies.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,11 @@
 # gradle
-org.gradle.jvmargs=-Xmx8G
+org.gradle.jvmargs=-Xmx8G -XX:+UseG1GC
 org.gradle.parallel=true
 
 # minecraft and fabric
 minecraft_version=1.20.2
 yarn_mappings=1.20.2+build.2
-loader_version=0.14.22
+loader_version=0.14.23
 fabric_api_version=0.90.0+1.20.2
 
 # viafabricplus
@@ -31,9 +31,9 @@ viabedrock_version=0.0.3-SNAPSHOT
 minecraftauth_version=2.1.7-SNAPSHOT
 
 # lenni0451 libs
-reflect_version=1.2.4
+reflect_version=1.3.0
 
 # other libs
 mod_menu_version=8.0.0
-netty_codec_http_version=4.1.96.Final
-mixin_extras_version=0.2.0-rc.5
+netty_codec_http_version=4.1.100.Final
+mixin_extras_version=0.2.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
1. Adds G1GC to make compiling morely comfortable for VFP,
4. Mixin Extras 0.2.0 has been finalized,
3. Updates Gradle to 8.4,
4. Updates Fabric Loader to 0.14.23,
5. Updates Netty Codec to 4.1.100,
6. Updates reflect to 1.3.0.