### PR TITLE
Update CI, fabric and other dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v2
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,8 +5,8 @@ org.gradle.parallel=true
 # Minecraft/Fabric
 minecraft_version=1.20.4
 yarn_mappings=1.20.4+build.3
-loader_version=0.15.6
-fabric_api_version=0.96.0+1.20.4
+loader_version=0.15.7
+fabric_api_version=0.96.1+1.20.4
 
 # Project Details
 mod_version=3.0.7-SNAPSHOT
@@ -14,8 +14,8 @@ maven_group=de.florianmichael
 archives_base_name=viafabricplus
 
 # ViaVersion Libraries
-viaversion_version=4.10.0-24w06a-SNAPSHOT
-viabackwards_version=4.10.0-24w06a-SNAPSHOT
+viaversion_version=4.10.0-24w07a-SNAPSHOT
+viabackwards_version=4.10.0-24w07a-SNAPSHOT
 vialegacy_version=2.2.22-SNAPSHOT
 viaaprilfools_version=2.0.11-SNAPSHOT
 vialoader_version=2.2.13-SNAPSHOT
@@ -27,7 +27,7 @@ viabedrock_version=0.0.5-SNAPSHOT
 raknet_transport_version=1.0.0.CR1-SNAPSHOT
 
 # Lenni0451 Libraries
-reflect_version=1.3.1
+reflect_version=1.3.2
 mcping_version=1.4.0
 
 # Misc Libraries


### PR DESCRIPTION
1. Updates wrapper-validation-action to v2 to resolve a deprecation warning in actions,
2. Updates fabric loader to 0.15.7 and API to 0.96.1 - mainly contains bug fixes but also bumps mixinextras to 0.3.5 there,
3. Updates reflect to 1.3.2,
4. Updates viaversion and viabackwards to 24w07a versions.

*(Testing should be considered before merging this)*