### PR TITLE
Feat/default port replacement

### DIFF
--- a/src/main/java/de/florianmichael/viafabricplus/fixes/ClientsideFixes.java
+++ b/src/main/java/de/florianmichael/viafabricplus/fixes/ClientsideFixes.java
@@ -148,15 +148,14 @@ public class ClientsideFixes {
     /**
      * Replaces the default port when parsing a server address if the default port should be replaced
      *
-     * @param info The server info
+     * @param info    The server info
+     * @param version The protocol version
      * @return The server address with the replaced default port
      */
-    public static ServerAddress replaceDefaultPort(final ServerInfo info) {
-        final boolean isBedrock = Objects.equals(((IServerInfo) info).viaFabricPlus$forcedVersion(), BedrockProtocolVersion.bedrockLatest);
-
+    public static ServerAddress replaceDefaultPort(final ServerInfo info, final ProtocolVersion version) {
         // If the default port for this entry should be replaced, check if the address already contains a port
         // We can't just replace vanilla's default port because a bedrock server might be running on the same port
-        if (BedrockSettings.global().replaceDefaultPort.getValue() && isBedrock && !info.address.contains(":")) {
+        if (BedrockSettings.global().replaceDefaultPort.getValue() && Objects.equals(version, BedrockProtocolVersion.bedrockLatest) && !info.address.contains(":")) {
             return ServerAddress.parse(info.address + ":" + 19132);
         } else {
             return ServerAddress.parse(info.address);

--- a/src/main/java/de/florianmichael/viafabricplus/fixes/ClientsideFixes.java
+++ b/src/main/java/de/florianmichael/viafabricplus/fixes/ClientsideFixes.java
@@ -156,11 +156,9 @@ public class ClientsideFixes {
         if (targetVersion == null) {
             targetVersion = ProtocolTranslator.getTargetVersion();
         }
-        final boolean isBedrock = Objects.equals(targetVersion, BedrockProtocolVersion.bedrockLatest);
-
         // If the default port for this entry should be replaced, check if the address already contains a port
         // We can't just replace vanilla's default port because a bedrock server might be running on the same port
-        if (BedrockSettings.global().replaceDefaultPort.getValue() && isBedrock && !info.address.contains(":")) {
+        if (BedrockSettings.global().replaceDefaultPort.getValue() && targetVersion.equals(BedrockProtocolVersion.bedrockLatest) && !info.address.contains(":")) {
             return ServerAddress.parse(info.address + ":" + 19132);
         } else {
             return ServerAddress.parse(info.address);

--- a/src/main/java/de/florianmichael/viafabricplus/fixes/ClientsideFixes.java
+++ b/src/main/java/de/florianmichael/viafabricplus/fixes/ClientsideFixes.java
@@ -152,13 +152,11 @@ public class ClientsideFixes {
      * @return The server address with the replaced default port
      */
     public static ServerAddress replaceDefaultPort(final ServerInfo info) {
-        ProtocolVersion targetVersion = ((IServerInfo) info).viaFabricPlus$forcedVersion();
-        if (targetVersion == null) {
-            targetVersion = ProtocolTranslator.getTargetVersion();
-        }
+        final boolean isBedrock = Objects.equals(((IServerInfo) info).viaFabricPlus$forcedVersion(), BedrockProtocolVersion.bedrockLatest);
+
         // If the default port for this entry should be replaced, check if the address already contains a port
         // We can't just replace vanilla's default port because a bedrock server might be running on the same port
-        if (BedrockSettings.global().replaceDefaultPort.getValue() && targetVersion.equals(BedrockProtocolVersion.bedrockLatest) && !info.address.contains(":")) {
+        if (BedrockSettings.global().replaceDefaultPort.getValue() && isBedrock && !info.address.contains(":")) {
             return ServerAddress.parse(info.address + ":" + 19132);
         } else {
             return ServerAddress.parse(info.address);

--- a/src/main/java/de/florianmichael/viafabricplus/fixes/ClientsideFixes.java
+++ b/src/main/java/de/florianmichael/viafabricplus/fixes/ClientsideFixes.java
@@ -148,17 +148,17 @@ public class ClientsideFixes {
     /**
      * Replaces the default port when parsing a server address if the default port should be replaced
      *
-     * @param info    The server info
+     * @param address The original address of the server
      * @param version The protocol version
      * @return The server address with the replaced default port
      */
-    public static ServerAddress replaceDefaultPort(final ServerInfo info, final ProtocolVersion version) {
+    public static ServerAddress replaceDefaultPort(final String address, final ProtocolVersion version) {
         // If the default port for this entry should be replaced, check if the address already contains a port
         // We can't just replace vanilla's default port because a bedrock server might be running on the same port
-        if (BedrockSettings.global().replaceDefaultPort.getValue() && Objects.equals(version, BedrockProtocolVersion.bedrockLatest) && !info.address.contains(":")) {
-            return ServerAddress.parse(info.address + ":" + 19132);
+        if (BedrockSettings.global().replaceDefaultPort.getValue() && Objects.equals(version, BedrockProtocolVersion.bedrockLatest) && !address.contains(":")) {
+            return ServerAddress.parse(address + ":" + 19132);
         } else {
-            return ServerAddress.parse(info.address);
+            return ServerAddress.parse(address);
         }
     }
 

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/base/integration/MixinMultiplayerScreen.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/base/integration/MixinMultiplayerScreen.java
@@ -19,15 +19,20 @@
 
 package de.florianmichael.viafabricplus.injection.mixin.base.integration;
 
+import com.llamalad7.mixinextras.sugar.Local;
+import de.florianmichael.viafabricplus.fixes.ClientsideFixes;
 import de.florianmichael.viafabricplus.screen.base.ProtocolSelectionScreen;
 import de.florianmichael.viafabricplus.settings.impl.GeneralSettings;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.multiplayer.MultiplayerScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.network.ServerAddress;
+import net.minecraft.client.network.ServerInfo;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MultiplayerScreen.class)
@@ -47,6 +52,11 @@ public abstract class MixinMultiplayerScreen extends Screen {
 
         // Set the button's position according to the configured orientation and add the button to the screen
         this.addDrawableChild(GeneralSettings.withOrientation(builder, buttonPosition, width, height).build());
+    }
+
+    @Redirect(method = "connect(Lnet/minecraft/client/network/ServerInfo;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ServerAddress;parse(Ljava/lang/String;)Lnet/minecraft/client/network/ServerAddress;"))
+    private ServerAddress replaceDefaultPort(String address, @Local(argsOnly = true) ServerInfo entry) {
+        return ClientsideFixes.replaceDefaultPort(entry);
     }
 
 }

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/base/integration/MixinMultiplayerScreen.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/base/integration/MixinMultiplayerScreen.java
@@ -60,10 +60,10 @@ public abstract class MixinMultiplayerScreen extends Screen {
     private ServerAddress replaceDefaultPort(String address, @Local(argsOnly = true) ServerInfo entry) {
         if (((IServerInfo) entry).viaFabricPlus$passedDirectConnectScreen()) {
             // If the user has already passed the direct connect screen, we use the target version
-            return ClientsideFixes.replaceDefaultPort(entry, ProtocolTranslator.getTargetVersion());
+            return ClientsideFixes.replaceDefaultPort(address, ProtocolTranslator.getTargetVersion());
         } else {
             // Otherwise the forced version is used
-            return ClientsideFixes.replaceDefaultPort(entry, ((IServerInfo) entry).viaFabricPlus$forcedVersion());
+            return ClientsideFixes.replaceDefaultPort(address, ((IServerInfo) entry).viaFabricPlus$forcedVersion());
         }
     }
 

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/base/integration/MixinMultiplayerScreen.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/base/integration/MixinMultiplayerScreen.java
@@ -21,6 +21,8 @@ package de.florianmichael.viafabricplus.injection.mixin.base.integration;
 
 import com.llamalad7.mixinextras.sugar.Local;
 import de.florianmichael.viafabricplus.fixes.ClientsideFixes;
+import de.florianmichael.viafabricplus.injection.access.IServerInfo;
+import de.florianmichael.viafabricplus.protocoltranslator.ProtocolTranslator;
 import de.florianmichael.viafabricplus.screen.base.ProtocolSelectionScreen;
 import de.florianmichael.viafabricplus.settings.impl.GeneralSettings;
 import net.minecraft.client.gui.screen.Screen;
@@ -56,7 +58,13 @@ public abstract class MixinMultiplayerScreen extends Screen {
 
     @Redirect(method = "connect(Lnet/minecraft/client/network/ServerInfo;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ServerAddress;parse(Ljava/lang/String;)Lnet/minecraft/client/network/ServerAddress;"))
     private ServerAddress replaceDefaultPort(String address, @Local(argsOnly = true) ServerInfo entry) {
-        return ClientsideFixes.replaceDefaultPort(entry);
+        if (((IServerInfo) entry).viaFabricPlus$passedDirectConnectScreen()) {
+            // If the user has already passed the direct connect screen, we use the target version
+            return ClientsideFixes.replaceDefaultPort(entry, ProtocolTranslator.getTargetVersion());
+        } else {
+            // Otherwise the forced version is used
+            return ClientsideFixes.replaceDefaultPort(entry, ((IServerInfo) entry).viaFabricPlus$forcedVersion());
+        }
     }
 
 }

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/base/perserverversion/MixinMultiplayerServerListPinger.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/base/perserverversion/MixinMultiplayerServerListPinger.java
@@ -40,7 +40,8 @@ public abstract class MixinMultiplayerServerListPinger {
 
     @Redirect(method = "add", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ServerAddress;parse(Ljava/lang/String;)Lnet/minecraft/client/network/ServerAddress;"))
     private ServerAddress replaceDefaultPort(String address, @Local(argsOnly = true) ServerInfo entry) {
-        return ClientsideFixes.replaceDefaultPort(entry);
+        // Replace port when pinging the server and the forced version is set
+        return ClientsideFixes.replaceDefaultPort(entry, ((IServerInfo) entry).viaFabricPlus$forcedVersion());
     }
 
     @Redirect(method = "add", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/ClientConnection;connect(Ljava/net/InetSocketAddress;ZLnet/minecraft/util/profiler/PerformanceLog;)Lnet/minecraft/network/ClientConnection;"))

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/base/perserverversion/MixinMultiplayerServerListPinger.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/base/perserverversion/MixinMultiplayerServerListPinger.java
@@ -41,7 +41,7 @@ public abstract class MixinMultiplayerServerListPinger {
     @Redirect(method = "add", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ServerAddress;parse(Ljava/lang/String;)Lnet/minecraft/client/network/ServerAddress;"))
     private ServerAddress replaceDefaultPort(String address, @Local(argsOnly = true) ServerInfo entry) {
         // Replace port when pinging the server and the forced version is set
-        return ClientsideFixes.replaceDefaultPort(entry, ((IServerInfo) entry).viaFabricPlus$forcedVersion());
+        return ClientsideFixes.replaceDefaultPort(address, ((IServerInfo) entry).viaFabricPlus$forcedVersion());
     }
 
     @Redirect(method = "add", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/ClientConnection;connect(Ljava/net/InetSocketAddress;ZLnet/minecraft/util/profiler/PerformanceLog;)Lnet/minecraft/network/ClientConnection;"))

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/base/perserverversion/MixinMultiplayerServerListPinger.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/base/perserverversion/MixinMultiplayerServerListPinger.java
@@ -21,9 +21,11 @@ package de.florianmichael.viafabricplus.injection.mixin.base.perserverversion;
 
 import com.llamalad7.mixinextras.sugar.Local;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import de.florianmichael.viafabricplus.fixes.ClientsideFixes;
 import de.florianmichael.viafabricplus.injection.access.IPerformanceLog;
 import de.florianmichael.viafabricplus.injection.access.IServerInfo;
 import net.minecraft.client.network.MultiplayerServerListPinger;
+import net.minecraft.client.network.ServerAddress;
 import net.minecraft.client.network.ServerInfo;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.util.profiler.PerformanceLog;
@@ -36,8 +38,13 @@ import java.net.InetSocketAddress;
 @Mixin(MultiplayerServerListPinger.class)
 public abstract class MixinMultiplayerServerListPinger {
 
+    @Redirect(method = "add", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ServerAddress;parse(Ljava/lang/String;)Lnet/minecraft/client/network/ServerAddress;"))
+    private ServerAddress replaceDefaultPort(String address, @Local(argsOnly = true) ServerInfo entry) {
+        return ClientsideFixes.replaceDefaultPort(entry);
+    }
+
     @Redirect(method = "add", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/ClientConnection;connect(Ljava/net/InetSocketAddress;ZLnet/minecraft/util/profiler/PerformanceLog;)Lnet/minecraft/network/ClientConnection;"))
-    private ClientConnection setForcedVersion(InetSocketAddress address, boolean useEpoll, PerformanceLog packetSizeLog, @Local ServerInfo serverInfo) {
+    private ClientConnection setForcedVersion(InetSocketAddress address, boolean useEpoll, PerformanceLog packetSizeLog, @Local(argsOnly = true) ServerInfo serverInfo) {
         final ProtocolVersion forcedVersion = ((IServerInfo) serverInfo).viaFabricPlus$forcedVersion();
 
         if (forcedVersion != null && !((IServerInfo) serverInfo).viaFabricPlus$passedDirectConnectScreen()) {

--- a/src/main/java/de/florianmichael/viafabricplus/settings/impl/BedrockSettings.java
+++ b/src/main/java/de/florianmichael/viafabricplus/settings/impl/BedrockSettings.java
@@ -55,6 +55,7 @@ public class BedrockSettings extends SettingGroup {
         }
     };
     public final BooleanSetting openPromptGUIToConfirmTransfer = new BooleanSetting(this, Text.translatable("bedrock_settings.viafabricplus.confirm_transfer_server_prompt"), true);
+    public final BooleanSetting replaceDefaultPort = new BooleanSetting(this, Text.translatable("bedrock_settings.viafabricplus.replace_default_port"), true);
 
     public BedrockSettings() {
         super(Text.translatable("setting_group_name.viafabricplus.bedrock"));

--- a/src/main/resources/assets/viafabricplus/lang/en_us.json
+++ b/src/main/resources/assets/viafabricplus/lang/en_us.json
@@ -48,6 +48,7 @@
 
   "bedrock_settings.viafabricplus.confirm_transfer_server_prompt": "Open prompt GUI to confirm transferring to other servers",
   "bedrock_settings.viafabricplus.click_to_set_bedrock_account": "Click to set account for Bedrock edition",
+  "bedrock_settings.viafabricplus.replace_default_port": "Replace default port in server list",
 
   "debug_settings.viafabricplus.queue_config_packets": "Queue config packets",
   "debug_settings.viafabricplus.disable_sequencing": "Disable sequencing",

--- a/src/main/resources/viafabricplus.mixins.json
+++ b/src/main/resources/viafabricplus.mixins.json
@@ -129,6 +129,7 @@
     "fixes.minecraft.item.MixinItemPlacementContext",
     "fixes.minecraft.item.MixinItemRenderer",
     "fixes.minecraft.item.MixinItemStack",
+    "fixes.minecraft.item.MixinMiningToolItem",
     "fixes.minecraft.item.MixinPickaxeItem",
     "fixes.minecraft.item.MixinShearsItem",
     "fixes.minecraft.item.MixinShovelItem",
@@ -199,8 +200,7 @@
     "vialegacy.MixinExtensionProtocolMetadataStorage",
     "vialegacy.MixinViaLegacyConfig",
     "viaversion.MixinConfig",
-    "viaversion.MixinProtocolVersion",
-    "fixes.minecraft.item.MixinMiningToolItem"
+    "viaversion.MixinProtocolVersion"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Introduces a new setting which will automatically replace Minecraft's default port (25565) to Bedrock edition's default port (19132) when selected, while the direct connect screen will always replace the port, server pinging and connecting only when bedrock is selected for that server.