### PR TITLE
Ensure we use JDK 21, not 17

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,7 +1,7 @@
-# Deploys the latest stable JDK 17 available and sets it to default without having to manually specify it here,
+# Deploys the latest stable JDK 21 available and sets it to default without having to manually specify it here,
 # Which includes using temurin as the distribution.
 before_install:
   - curl -s "https://get.sdkman.io" | bash
   - source ~/.sdkman/bin/sdkman-init.sh
-  - sdk install java 17.0.10-tem
-  - sdk use java 17.0.10-tem
+  - sdk install java 21.0.3-tem
+  - sdk use java 21.0.3-tem

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -55,7 +55,7 @@
     "fabric-particles-v1": ">=1.1.6",
     "fabric-registry-sync-v0": ">=4.0.13",
     "minecraft": ">=1.20.5",
-    "java": ">=17"
+    "java": ">=21"
   },
   "breaks": {
     "viafabric": "*"

--- a/src/main/resources/viafabricplus.mixins.json
+++ b/src/main/resources/viafabricplus.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "de.florianmichael.viafabricplus.injection.mixin",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "plugin": "de.florianmichael.viafabricplus.injection.ViaFabricPlusMixinPlugin",
   "client": [
     "base.MixinMain",


### PR DESCRIPTION
Since Minecraft 1.20.5/6 ultimately dropped support for JDK 20 and lower, We need to ensure ViaFabricPlus uses Java 21 or greater as required dependency.