### PR TITLE
Bump Via* to 4.10.3 for 1.20.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,8 +5,8 @@ org.gradle.parallel=true
 # Minecraft/Fabric
 minecraft_version=1.20.4
 yarn_mappings=1.20.4+build.3
-loader_version=0.15.10
-fabric_api_version=0.97.0+1.20.4
+loader_version=0.15.11
+fabric_api_version=0.97.1+1.20.4
 
 # Project Details
 mod_version=3.1.1
@@ -14,8 +14,8 @@ maven_group=de.florianmichael
 archives_base_name=ViaFabricPlus
 
 # ViaVersion Libraries
-viaversion_version=4.10.1
-viabackwards_version=4.10.1
+viaversion_version=4.10.3-SNAPSHOT
+viabackwards_version=4.10.3-SNAPSHOT
 vialegacy_version=2.2.22
 viaaprilfools_version=2.0.12
 vialoader_version=2.2.13


### PR DESCRIPTION
Updates ViaVersion and ViaBackwards dependencies to 4.10.3-SNAPSHOT to port required bug fixes over to 1.20.4 and also bumps fabric loader + API to latest builds available for it.

This needs to be tested before merging.