### PR TITLE
Added setting to hide nether portal sprite in download terrain screen

### DIFF
--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/screen/MixinDownloadingTerrainScreen.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/screen/MixinDownloadingTerrainScreen.java
@@ -22,6 +22,7 @@ package de.florianmichael.viafabricplus.injection.mixin.fixes.minecraft.screen;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import de.florianmichael.viafabricplus.injection.access.IDownloadingTerrainScreen;
 import de.florianmichael.viafabricplus.protocoltranslator.ProtocolTranslator;
+import de.florianmichael.viafabricplus.settings.impl.VisualSettings;
 import net.minecraft.client.gui.screen.DownloadingTerrainScreen;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.network.packet.c2s.common.KeepAliveC2SPacket;
@@ -33,6 +34,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(DownloadingTerrainScreen.class)
@@ -41,6 +43,10 @@ public abstract class MixinDownloadingTerrainScreen extends Screen implements ID
     @Shadow
     @Final
     private long loadStartTime;
+
+    @Shadow
+    @Final
+    private DownloadingTerrainScreen.WorldEntryReason worldEntryReason;
 
     @Unique
     private int viaFabricPlus$tickCounter;
@@ -53,6 +59,15 @@ public abstract class MixinDownloadingTerrainScreen extends Screen implements ID
 
     public MixinDownloadingTerrainScreen(Text title) {
         super(title);
+    }
+
+    @Redirect(method = "renderBackground", at = @At(value = "FIELD", target = "Lnet/minecraft/client/gui/screen/DownloadingTerrainScreen;worldEntryReason:Lnet/minecraft/client/gui/screen/DownloadingTerrainScreen$WorldEntryReason;"))
+    private DownloadingTerrainScreen.WorldEntryReason hideDownloadTerrainScreenTransitionEffects(DownloadingTerrainScreen downloadingTerrainScreen) {
+        if (VisualSettings.global().hideDownloadTerrainScreenTransitionEffects.isEnabled()) {
+            return DownloadingTerrainScreen.WorldEntryReason.OTHER;
+        } else {
+            return this.worldEntryReason;
+        }
     }
 
     @Inject(method = "tick", at = @At("HEAD"), cancellable = true)

--- a/src/main/java/de/florianmichael/viafabricplus/settings/base/VersionedBooleanSetting.java
+++ b/src/main/java/de/florianmichael/viafabricplus/settings/base/VersionedBooleanSetting.java
@@ -29,9 +29,9 @@ import net.raphimc.vialoader.util.VersionRange;
 
 public class VersionedBooleanSetting extends AbstractSetting<Integer> {
 
-    private static final int AUTO_INDEX = 2;
-    private static final int DISABLED_INDEX = 1;
-    private static final int ENABLED_INDEX = 0;
+    public static final int AUTO_INDEX = 2;
+    public static final int DISABLED_INDEX = 1;
+    public static final int ENABLED_INDEX = 0;
 
     private final VersionRange protocolRange;
 

--- a/src/main/java/de/florianmichael/viafabricplus/settings/impl/VisualSettings.java
+++ b/src/main/java/de/florianmichael/viafabricplus/settings/impl/VisualSettings.java
@@ -30,6 +30,9 @@ public class VisualSettings extends SettingGroup {
 
     private static final VisualSettings INSTANCE = new VisualSettings();
 
+    // 1.21 -> 1.20.5
+    public final VersionedBooleanSetting hideDownloadTerrainScreenTransitionEffects = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.hide_download_terrain_screen_transition_effects"), VersionRange.andOlder(ProtocolVersion.v1_20_5));
+
     // 1.20.3 -> 1.20.2
     public final VersionedBooleanSetting hidePrioritySelectionsInJigsawScreen = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.hide_priority_selections_in_jigsaw_screen"), VersionRange.andOlder(ProtocolVersion.v1_20_2));
 
@@ -73,6 +76,8 @@ public class VisualSettings extends SettingGroup {
 
     public VisualSettings() {
         super(Text.translatable("setting_group_name.viafabricplus.visual"));
+
+        this.hideDownloadTerrainScreenTransitionEffects.setValue(VersionedBooleanSetting.DISABLED_INDEX);
     }
 
     public static VisualSettings global() {

--- a/src/main/resources/assets/viafabricplus/lang/de_de.json
+++ b/src/main/resources/assets/viafabricplus/lang/de_de.json
@@ -81,6 +81,7 @@
   "visual_settings.viafabricplus.disable_secure_chat_warning": "Warnung für sicheren Chat deaktivieren",
   "visual_settings.viafabricplus.hide_signature_indicator": "Signaturanzeige verstecken",
   "visual_settings.viafabricplus.hide_priority_selections_in_jigsaw_screen": "Prioritätsauswahlen im Puzzle-Bildschirm ausblenden",
+  "visual_settings.viafabricplus.hide_download_terrain_screen_transition_effects": "Übergangseffekte im Download-Gelände-Bildschirm ausblenden",
   "visual_settings.viafabricplus.replace_petrified_oak_slab": "Versteinerter Eichenschwelle mit 'Unbekannt'-Textur ersetzen",
   "visual_settings.viafabricplus.emulate_armor_hud": "Rüstungs-HUD emulieren",
   "visual_settings.viafabricplus.remove_newer_features_from_command_block_screen": "Neuere Funktionen vom Befehlsblock entfernen",

--- a/src/main/resources/assets/viafabricplus/lang/en_us.json
+++ b/src/main/resources/assets/viafabricplus/lang/en_us.json
@@ -83,6 +83,7 @@
   "visual_settings.viafabricplus.disable_secure_chat_warning": "Disable Secure Chat warning",
   "visual_settings.viafabricplus.hide_signature_indicator": "Hide signature indicator",
   "visual_settings.viafabricplus.hide_priority_selections_in_jigsaw_screen": "Hide priority selections in Jigsaw screen",
+  "visual_settings.viafabricplus.hide_download_terrain_screen_transition_effects": "Hide download terrain screen transition effects",
   "visual_settings.viafabricplus.replace_petrified_oak_slab": "Replace petrified oak slab texture with the 'unknown' texture",
   "visual_settings.viafabricplus.emulate_armor_hud": "Emulate Armor HUD",
   "visual_settings.viafabricplus.remove_newer_features_from_command_block_screen": "Remove newer features from the Command Block screen",


### PR DESCRIPTION
This setting renders the default panorama background instead of a nether portal sprite when you are in the download terrain screen. This is better because some servers for example send a wrong dimension on respawn, which causes the nether portal sprite to be rendered.