### PR TITLE
Add Item Swing Usage To Food/Potions <=1.7.x

### DIFF
--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
@@ -48,15 +48,14 @@ public abstract class MixinHeldItemRenderer {
             slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getUseAction()Lnet/minecraft/util/UseAction;")),
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 2, shift = At.Shift.AFTER))
     private void transformSwordBlockingPosition(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
-        final boolean enableItemSwingUsage = VisualSettings.global().enableItemSwingUsage.isEnabled();
-        if (!VisualSettings.global().enableSwordBlocking.isEnabled() && !enableItemSwingUsage) {
+        if (!VisualSettings.global().enableSwordBlocking.isEnabled()) {
             return;
         }
 
         final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
         final int direction = arm == Arm.RIGHT ? 1 : -1;
 
-        if (enableItemSwingUsage) {
+        if (VisualSettings.global().enableItemSwingUsage.isEnabled()) {
             applySwingOffset(matrices, arm, swingProgress);
         }
 

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
@@ -40,11 +40,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(HeldItemRenderer.class)
 public abstract class MixinHeldItemRenderer {
-    
+
     @Shadow
     protected abstract void applySwingOffset(MatrixStack matrices, Arm arm, float swingProgress);
-    
-    
+
     @Inject(method = "renderFirstPersonItem",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;renderItem(Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", ordinal = 1))
     private void transformItemPositions1_7(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack stack, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
@@ -58,7 +57,7 @@ public abstract class MixinHeldItemRenderer {
             matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(direction * 5.0F));
         }
     }
-    
+
     @Inject(method = "renderFirstPersonItem",
             slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getUseAction()Lnet/minecraft/util/UseAction;")),
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 2, shift = At.Shift.AFTER))
@@ -67,19 +66,19 @@ public abstract class MixinHeldItemRenderer {
         if (!VisualSettings.global().enableSwordBlocking.isEnabled() && !blockHitAnimation) {
             return;
         }
-        
+
         final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
         final int direction = arm == Arm.RIGHT ? 1 : -1;
-        
+
         if (blockHitAnimation) {
             applySwingOffset(matrices, arm, swingProgress);
         }
-        
+
         // Values stripped from early 1.9 snapshots, 15w33b specifically, which is the version prior to them removing sword blocking
         matrices.translate(direction * -0.14142136F, 0.08F, 0.14142136F);
         matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(-102.25F));
         matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(direction * 13.365F));
         matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(direction * 78.05F));
     }
-    
+
 }

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
@@ -48,14 +48,15 @@ public abstract class MixinHeldItemRenderer {
             slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getUseAction()Lnet/minecraft/util/UseAction;")),
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 2, shift = At.Shift.AFTER))
     private void transformSwordBlockingPosition(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
-        if (!VisualSettings.global().enableSwordBlocking.isEnabled()) {
+        final boolean enableItemSwingUsage = VisualSettings.global().enableItemSwingUsage.isEnabled();
+        if (!VisualSettings.global().enableSwordBlocking.isEnabled() && !enableItemSwingUsage) {
             return;
         }
 
         final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
         final int direction = arm == Arm.RIGHT ? 1 : -1;
 
-        if (VisualSettings.global().enableItemSwingUsage.isEnabled()) {
+        if (enableItemSwingUsage) {
             applySwingOffset(matrices, arm, swingProgress);
         }
 

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
@@ -77,6 +77,15 @@ public abstract class MixinHeldItemRenderer {
     }
 
     @Inject(method = "renderFirstPersonItem",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 5, shift = At.Shift.AFTER))
+    private void applyBowSwingOffset1_7(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
+        if (VisualSettings.global().enableItemSwingUsage.isEnabled()) {
+            final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
+            applySwingOffset(matrices, arm, swingProgress);
+        }
+    }
+
+    @Inject(method = "renderFirstPersonItem",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;renderItem(Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", ordinal = 1))
     private void transformItemPosition1_7(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack stack, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
         // Modifies the handheld position to be slightly tilted like in 1.7 and prior

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
@@ -45,14 +45,6 @@ public abstract class MixinHeldItemRenderer {
     @Shadow
     protected abstract void applySwingOffset(MatrixStack matrices, Arm arm, float swingProgress);
 
-    @Unique
-    private void applyItemSwingUsage(MatrixStack matrices, AbstractClientPlayerEntity player, Hand hand, float swingProgress) {
-        if (VisualSettings.global().enableItemSwingUsage.isEnabled()) {
-            final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
-            applySwingOffset(matrices, arm, swingProgress);
-        }
-    }
-
     @Inject(method = "renderFirstPersonItem",
             slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getUseAction()Lnet/minecraft/util/UseAction;")),
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 2, shift = At.Shift.AFTER))
@@ -64,9 +56,7 @@ public abstract class MixinHeldItemRenderer {
         final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
         final int direction = arm == Arm.RIGHT ? 1 : -1;
 
-        if (VisualSettings.global().enableItemSwingUsage.isEnabled()) {
-            applySwingOffset(matrices, arm, swingProgress);
-        }
+        viaFabricPlus$applyItemSwingUsage(player, hand, swingProgress, matrices);
 
         // Values stripped from early 1.9 snapshots, 15w33b specifically, which is the version prior to them removing sword blocking
         matrices.translate(direction * -0.14142136F, 0.08F, 0.14142136F);
@@ -78,13 +68,13 @@ public abstract class MixinHeldItemRenderer {
     @Inject(method = "renderFirstPersonItem",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 3, shift = At.Shift.AFTER))
     private void applyFoodSwingOffset(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
-        applyItemSwingUsage(matrices, player, hand, swingProgress);
+        viaFabricPlus$applyItemSwingUsage(player, hand, swingProgress, matrices);
     }
 
     @Inject(method = "renderFirstPersonItem",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 5, shift = At.Shift.AFTER))
     private void applyBowSwingOffset(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
-        applyItemSwingUsage(matrices, player, hand, swingProgress);
+        viaFabricPlus$applyItemSwingUsage(player, hand, swingProgress, matrices);
     }
 
     @Inject(method = "renderFirstPersonItem",
@@ -99,6 +89,14 @@ public abstract class MixinHeldItemRenderer {
             matrices.scale(scale, scale, scale);
             matrices.translate(direction * -0.084F, 0.059F, 0.08F);
             matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(direction * 5.0F));
+        }
+    }
+
+    @Unique
+    private void viaFabricPlus$applyItemSwingUsage(AbstractClientPlayerEntity player, Hand hand, float swingProgress, MatrixStack matrices) {
+        if (VisualSettings.global().enableItemSwingUsage.isEnabled()) {
+            final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
+            applySwingOffset(matrices, arm, swingProgress);
         }
     }
 

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
@@ -40,46 +40,46 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(HeldItemRenderer.class)
 public abstract class MixinHeldItemRenderer {
-	
-	@Shadow
-	protected abstract void applySwingOffset(MatrixStack matrices, Arm arm, float swingProgress);
-	
-	
-	@Inject(method = "renderFirstPersonItem",
-			at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;renderItem(Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", ordinal = 1))
-	private void transformItemPositions1_7(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack stack, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
-		// Modifies the handheld position to be slightly tilted like in 1.7 and prior
-		if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_7_6) && !(stack.getItem() instanceof BlockItem)) {
-			final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
-			final int direction = arm == Arm.RIGHT ? 1 : -1;
-			final float scale = 0.7585F / 0.86F;
-			matrices.scale(scale, scale, scale);
-			matrices.translate(direction * -0.084F, 0.059F, 0.08F);
-			matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(direction * 5.0F));
-		}
-	}
-	
-	@Inject(method = "renderFirstPersonItem",
-			slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getUseAction()Lnet/minecraft/util/UseAction;")),
-			at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 2, shift = At.Shift.AFTER))
-	private void transformSwordBlockingPosition(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
-		final boolean blockHitAnimation = VisualSettings.global().enableBlockHitAnimation.isEnabled();
-		if (!VisualSettings.global().enableSwordBlocking.isEnabled() && !blockHitAnimation) {
-			return;
-		}
-		
-		final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
-		final int direction = arm == Arm.RIGHT ? 1 : -1;
-		
-		if (blockHitAnimation) {
-			applySwingOffset(matrices, arm, swingProgress);
-		}
-		
-		// Values stripped from early 1.9 snapshots, 15w33b specifically, which is the version prior to them removing sword blocking
-		matrices.translate(direction * -0.14142136F, 0.08F, 0.14142136F);
-		matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(-102.25F));
-		matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(direction * 13.365F));
-		matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(direction * 78.05F));
-	}
-	
+    
+    @Shadow
+    protected abstract void applySwingOffset(MatrixStack matrices, Arm arm, float swingProgress);
+    
+    
+    @Inject(method = "renderFirstPersonItem",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;renderItem(Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", ordinal = 1))
+    private void transformItemPositions1_7(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack stack, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
+        // Modifies the handheld position to be slightly tilted like in 1.7 and prior
+        if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_7_6) && !(stack.getItem() instanceof BlockItem)) {
+            final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
+            final int direction = arm == Arm.RIGHT ? 1 : -1;
+            final float scale = 0.7585F / 0.86F;
+            matrices.scale(scale, scale, scale);
+            matrices.translate(direction * -0.084F, 0.059F, 0.08F);
+            matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(direction * 5.0F));
+        }
+    }
+    
+    @Inject(method = "renderFirstPersonItem",
+            slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getUseAction()Lnet/minecraft/util/UseAction;")),
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 2, shift = At.Shift.AFTER))
+    private void transformSwordBlockingPosition(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
+        final boolean blockHitAnimation = VisualSettings.global().enableBlockHitAnimation.isEnabled();
+        if (!VisualSettings.global().enableSwordBlocking.isEnabled() && !blockHitAnimation) {
+            return;
+        }
+        
+        final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
+        final int direction = arm == Arm.RIGHT ? 1 : -1;
+        
+        if (blockHitAnimation) {
+            applySwingOffset(matrices, arm, swingProgress);
+        }
+        
+        // Values stripped from early 1.9 snapshots, 15w33b specifically, which is the version prior to them removing sword blocking
+        matrices.translate(direction * -0.14142136F, 0.08F, 0.14142136F);
+        matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(-102.25F));
+        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(direction * 13.365F));
+        matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(direction * 78.05F));
+    }
+    
 }

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
@@ -48,15 +48,15 @@ public abstract class MixinHeldItemRenderer {
             slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getUseAction()Lnet/minecraft/util/UseAction;")),
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 2, shift = At.Shift.AFTER))
     private void transformSwordBlockingPosition(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
-        final boolean blockHitAnimation = VisualSettings.global().enableBlockHitAnimation.isEnabled();
-        if (!VisualSettings.global().enableSwordBlocking.isEnabled() && !blockHitAnimation) {
+        final boolean enableItemSwingUsage = VisualSettings.global().enableItemSwingUsage.isEnabled();
+        if (!VisualSettings.global().enableSwordBlocking.isEnabled() && !enableItemSwingUsage) {
             return;
         }
 
         final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
         final int direction = arm == Arm.RIGHT ? 1 : -1;
 
-        if (blockHitAnimation) {
+        if (enableItemSwingUsage) {
             applySwingOffset(matrices, arm, swingProgress);
         }
 
@@ -67,6 +67,14 @@ public abstract class MixinHeldItemRenderer {
         matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(direction * 78.05F));
     }
 
+    @Inject(method = "renderFirstPersonItem",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 3, shift = At.Shift.AFTER))
+    private void applyFoodSwingOffset1_7(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
+        if (VisualSettings.global().enableItemSwingUsage.isEnabled()) {
+            final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
+            applySwingOffset(matrices, arm, swingProgress);
+        }
+    }
 
     @Inject(method = "renderFirstPersonItem",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;renderItem(Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", ordinal = 1))

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
@@ -48,15 +48,14 @@ public abstract class MixinHeldItemRenderer {
             slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getUseAction()Lnet/minecraft/util/UseAction;")),
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 2, shift = At.Shift.AFTER))
     private void transformSwordBlockingPosition(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
-        final boolean enableItemSwingUsage = VisualSettings.global().enableItemSwingUsage.isEnabled();
-        if (!VisualSettings.global().enableSwordBlocking.isEnabled() && !enableItemSwingUsage) {
+        if (!VisualSettings.global().enableSwordBlocking.isEnabled()) {
             return;
         }
 
         final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
         final int direction = arm == Arm.RIGHT ? 1 : -1;
 
-        if (enableItemSwingUsage) {
+        if (VisualSettings.global().enableItemSwingUsage.isEnabled()) {
             applySwingOffset(matrices, arm, swingProgress);
         }
 
@@ -69,7 +68,7 @@ public abstract class MixinHeldItemRenderer {
 
     @Inject(method = "renderFirstPersonItem",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 3, shift = At.Shift.AFTER))
-    private void applyFoodSwingOffset1_7(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
+    private void applyFoodSwingOffset(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
         if (VisualSettings.global().enableItemSwingUsage.isEnabled()) {
             final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
             applySwingOffset(matrices, arm, swingProgress);
@@ -78,7 +77,7 @@ public abstract class MixinHeldItemRenderer {
 
     @Inject(method = "renderFirstPersonItem",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 5, shift = At.Shift.AFTER))
-    private void applyBowSwingOffset1_7(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
+    private void applyBowSwingOffset(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
         if (VisualSettings.global().enableItemSwingUsage.isEnabled()) {
             final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
             applySwingOffset(matrices, arm, swingProgress);

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
@@ -33,6 +33,7 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.math.RotationAxis;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Slice;
@@ -43,6 +44,14 @@ public abstract class MixinHeldItemRenderer {
 
     @Shadow
     protected abstract void applySwingOffset(MatrixStack matrices, Arm arm, float swingProgress);
+
+    @Unique
+    private void applyItemSwingUsage(MatrixStack matrices, AbstractClientPlayerEntity player, Hand hand, float swingProgress) {
+        if (VisualSettings.global().enableItemSwingUsage.isEnabled()) {
+            final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
+            applySwingOffset(matrices, arm, swingProgress);
+        }
+    }
 
     @Inject(method = "renderFirstPersonItem",
             slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getUseAction()Lnet/minecraft/util/UseAction;")),
@@ -69,19 +78,13 @@ public abstract class MixinHeldItemRenderer {
     @Inject(method = "renderFirstPersonItem",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 3, shift = At.Shift.AFTER))
     private void applyFoodSwingOffset(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
-        if (VisualSettings.global().enableItemSwingUsage.isEnabled()) {
-            final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
-            applySwingOffset(matrices, arm, swingProgress);
-        }
+        applyItemSwingUsage(matrices, player, hand, swingProgress);
     }
 
     @Inject(method = "renderFirstPersonItem",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 5, shift = At.Shift.AFTER))
     private void applyBowSwingOffset(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
-        if (VisualSettings.global().enableItemSwingUsage.isEnabled()) {
-            final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
-            applySwingOffset(matrices, arm, swingProgress);
-        }
+        applyItemSwingUsage(matrices, player, hand, swingProgress);
     }
 
     @Inject(method = "renderFirstPersonItem",

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
@@ -19,11 +19,14 @@
 
 package de.florianmichael.viafabricplus.injection.mixin.fixes.minecraft.item;
 
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import de.florianmichael.viafabricplus.protocoltranslator.ProtocolTranslator;
 import de.florianmichael.viafabricplus.settings.impl.VisualSettings;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.item.HeldItemRenderer;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.item.BlockItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Arm;
 import net.minecraft.util.Hand;
@@ -37,31 +40,46 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(HeldItemRenderer.class)
 public abstract class MixinHeldItemRenderer {
-
-    @Shadow
-    protected abstract void applySwingOffset(MatrixStack matrices, Arm arm, float swingProgress);
-
-    @Inject(method = "renderFirstPersonItem",
-            slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getUseAction()Lnet/minecraft/util/UseAction;")),
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 2, shift = At.Shift.AFTER))
-    private void transformSwordBlockingPosition(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
-        final boolean blockHitAnimation = VisualSettings.global().enableBlockHitAnimation.isEnabled();
-        if (!VisualSettings.global().enableSwordBlocking.isEnabled() && !blockHitAnimation) {
-            return;
-        }
-
-        final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
-        final int direction = arm == Arm.RIGHT ? 1 : -1;
-
-        if (blockHitAnimation) {
-            applySwingOffset(matrices, arm, swingProgress);
-        }
-
-        // Values stripped from early 1.9 snapshots, 15w33b specifically, which is the version prior to them removing sword blocking
-        matrices.translate(direction * -0.14142136F, 0.08F, 0.14142136F);
-        matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(-102.25F));
-        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(direction * 13.365F));
-        matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(direction * 78.05F));
-    }
-
+	
+	@Shadow
+	protected abstract void applySwingOffset(MatrixStack matrices, Arm arm, float swingProgress);
+	
+	
+	@Inject(method = "renderFirstPersonItem",
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;renderItem(Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", ordinal = 1))
+	private void transformItemPositions1_7(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack stack, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
+		// Modifies the handheld position to be slightly tilted like in 1.7 and prior
+		if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_7_6) && !(stack.getItem() instanceof BlockItem)) {
+			final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
+			final int direction = arm == Arm.RIGHT ? 1 : -1;
+			final float scale = 0.7585F / 0.86F;
+			matrices.scale(scale, scale, scale);
+			matrices.translate(direction * -0.084F, 0.059F, 0.08F);
+			matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(direction * 5.0F));
+		}
+	}
+	
+	@Inject(method = "renderFirstPersonItem",
+			slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getUseAction()Lnet/minecraft/util/UseAction;")),
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 2, shift = At.Shift.AFTER))
+	private void transformSwordBlockingPosition(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
+		final boolean blockHitAnimation = VisualSettings.global().enableBlockHitAnimation.isEnabled();
+		if (!VisualSettings.global().enableSwordBlocking.isEnabled() && !blockHitAnimation) {
+			return;
+		}
+		
+		final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
+		final int direction = arm == Arm.RIGHT ? 1 : -1;
+		
+		if (blockHitAnimation) {
+			applySwingOffset(matrices, arm, swingProgress);
+		}
+		
+		// Values stripped from early 1.9 snapshots, 15w33b specifically, which is the version prior to them removing sword blocking
+		matrices.translate(direction * -0.14142136F, 0.08F, 0.14142136F);
+		matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(-102.25F));
+		matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(direction * 13.365F));
+		matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(direction * 78.05F));
+	}
+	
 }

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
@@ -56,7 +56,7 @@ public abstract class MixinHeldItemRenderer {
         final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
         final int direction = arm == Arm.RIGHT ? 1 : -1;
 
-        viaFabricPlus$applyItemSwingUsage(player, hand, swingProgress, matrices);
+        viaFabricPlus$applySwingOffset(player, hand, swingProgress, matrices);
 
         // Values stripped from early 1.9 snapshots, 15w33b specifically, which is the version prior to them removing sword blocking
         matrices.translate(direction * -0.14142136F, 0.08F, 0.14142136F);
@@ -68,13 +68,13 @@ public abstract class MixinHeldItemRenderer {
     @Inject(method = "renderFirstPersonItem",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 3, shift = At.Shift.AFTER))
     private void applyFoodSwingOffset(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
-        viaFabricPlus$applyItemSwingUsage(player, hand, swingProgress, matrices);
+        viaFabricPlus$applySwingOffset(player, hand, swingProgress, matrices);
     }
 
     @Inject(method = "renderFirstPersonItem",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 5, shift = At.Shift.AFTER))
     private void applyBowSwingOffset(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
-        viaFabricPlus$applyItemSwingUsage(player, hand, swingProgress, matrices);
+        viaFabricPlus$applySwingOffset(player, hand, swingProgress, matrices);
     }
 
     @Inject(method = "renderFirstPersonItem",
@@ -93,8 +93,8 @@ public abstract class MixinHeldItemRenderer {
     }
 
     @Unique
-    private void viaFabricPlus$applyItemSwingUsage(AbstractClientPlayerEntity player, Hand hand, float swingProgress, MatrixStack matrices) {
-        if (VisualSettings.global().enableItemSwingUsage.isEnabled()) {
+    private void viaFabricPlus$applySwingOffset(AbstractClientPlayerEntity player, Hand hand, float swingProgress, MatrixStack matrices) {
+        if (VisualSettings.global().swingHandOnItemUse.isEnabled()) {
             final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
             applySwingOffset(matrices, arm, swingProgress);
         }

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
@@ -46,11 +46,12 @@ public abstract class MixinHeldItemRenderer {
 
     @Inject(method = "renderFirstPersonItem",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;renderItem(Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", ordinal = 1))
-    private void transformItemPositions1_7(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack stack, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
+    private void transformItemPosition1_7(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack stack, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
         // Modifies the handheld position to be slightly tilted like in 1.7 and prior
         if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_7_6) && !(stack.getItem() instanceof BlockItem)) {
             final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
             final int direction = arm == Arm.RIGHT ? 1 : -1;
+
             final float scale = 0.7585F / 0.86F;
             matrices.scale(scale, scale, scale);
             matrices.translate(direction * -0.084F, 0.059F, 0.08F);

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
@@ -45,21 +45,6 @@ public abstract class MixinHeldItemRenderer {
     protected abstract void applySwingOffset(MatrixStack matrices, Arm arm, float swingProgress);
 
     @Inject(method = "renderFirstPersonItem",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;renderItem(Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", ordinal = 1))
-    private void transformItemPosition1_7(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack stack, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
-        // Modifies the handheld position to be slightly tilted like in 1.7 and prior
-        if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_7_6) && !(stack.getItem() instanceof BlockItem)) {
-            final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
-            final int direction = arm == Arm.RIGHT ? 1 : -1;
-
-            final float scale = 0.7585F / 0.86F;
-            matrices.scale(scale, scale, scale);
-            matrices.translate(direction * -0.084F, 0.059F, 0.08F);
-            matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(direction * 5.0F));
-        }
-    }
-
-    @Inject(method = "renderFirstPersonItem",
             slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getUseAction()Lnet/minecraft/util/UseAction;")),
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 2, shift = At.Shift.AFTER))
     private void transformSwordBlockingPosition(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
@@ -80,6 +65,22 @@ public abstract class MixinHeldItemRenderer {
         matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(-102.25F));
         matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(direction * 13.365F));
         matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(direction * 78.05F));
+    }
+
+
+    @Inject(method = "renderFirstPersonItem",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;renderItem(Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", ordinal = 1))
+    private void transformItemPosition1_7(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack stack, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
+        // Modifies the handheld position to be slightly tilted like in 1.7 and prior
+        if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_7_6) && !(stack.getItem() instanceof BlockItem)) {
+            final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
+            final int direction = arm == Arm.RIGHT ? 1 : -1;
+
+            final float scale = 0.7585F / 0.86F;
+            matrices.scale(scale, scale, scale);
+            matrices.translate(direction * -0.084F, 0.059F, 0.08F);
+            matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(direction * 5.0F));
+        }
     }
 
 }

--- a/src/main/java/de/florianmichael/viafabricplus/settings/impl/VisualSettings.java
+++ b/src/main/java/de/florianmichael/viafabricplus/settings/impl/VisualSettings.java
@@ -80,7 +80,7 @@ public class VisualSettings extends SettingGroup {
     public final VersionedBooleanSetting enableSwordBlocking = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.enable_sword_blocking"), VersionRange.andOlder(ProtocolVersion.v1_8));
 
     // 1.8.x -> 1.7.6 - 1.7.10
-    public final VersionedBooleanSetting enableItemSwingUsage = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.enable_enable_item_swing_usage"), VersionRange.andOlder(ProtocolVersion.v1_7_6));
+    public final VersionedBooleanSetting enableItemSwingUsage = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.enable_item_swing_usage"), VersionRange.andOlder(ProtocolVersion.v1_7_6));
     public final VersionedBooleanSetting enableLegacyTablist = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.enable_legacy_tablist"), VersionRange.andOlder(ProtocolVersion.v1_7_6));
 
     // 1.0.0-1.0.1 -> b1.8-b1.8.1

--- a/src/main/java/de/florianmichael/viafabricplus/settings/impl/VisualSettings.java
+++ b/src/main/java/de/florianmichael/viafabricplus/settings/impl/VisualSettings.java
@@ -80,7 +80,7 @@ public class VisualSettings extends SettingGroup {
     public final VersionedBooleanSetting enableSwordBlocking = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.enable_sword_blocking"), VersionRange.andOlder(ProtocolVersion.v1_8));
 
     // 1.8.x -> 1.7.6 - 1.7.10
-    public final VersionedBooleanSetting enableBlockHitAnimation = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.enable_block_hit_animation"), VersionRange.andOlder(ProtocolVersion.v1_7_6));
+    public final VersionedBooleanSetting enableItemSwingUsage = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.enable_enable_item_swing_usage"), VersionRange.andOlder(ProtocolVersion.v1_7_6));
     public final VersionedBooleanSetting enableLegacyTablist = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.enable_legacy_tablist"), VersionRange.andOlder(ProtocolVersion.v1_7_6));
 
     // 1.0.0-1.0.1 -> b1.8-b1.8.1

--- a/src/main/java/de/florianmichael/viafabricplus/settings/impl/VisualSettings.java
+++ b/src/main/java/de/florianmichael/viafabricplus/settings/impl/VisualSettings.java
@@ -80,7 +80,7 @@ public class VisualSettings extends SettingGroup {
     public final VersionedBooleanSetting enableSwordBlocking = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.enable_sword_blocking"), VersionRange.andOlder(ProtocolVersion.v1_8));
 
     // 1.8.x -> 1.7.6 - 1.7.10
-    public final VersionedBooleanSetting enableItemSwingUsage = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.enable_item_swing_usage"), VersionRange.andOlder(ProtocolVersion.v1_7_6));
+    public final VersionedBooleanSetting swingHandOnItemUse = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.swing_hand_on_item_use"), VersionRange.andOlder(ProtocolVersion.v1_7_6));
     public final VersionedBooleanSetting enableLegacyTablist = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.enable_legacy_tablist"), VersionRange.andOlder(ProtocolVersion.v1_7_6));
 
     // 1.0.0-1.0.1 -> b1.8-b1.8.1

--- a/src/main/resources/assets/viafabricplus/lang/de_de.json
+++ b/src/main/resources/assets/viafabricplus/lang/de_de.json
@@ -89,7 +89,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Alte Laufanimation",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Verhalten des Schriftarten-Renderers ändern",
   "visual_settings.viafabricplus.enable_sword_blocking": "Schwertblockierung aktivieren",
-  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Block-Trefferanimation aktivieren",
+  "visual_settings.viafabricplus.enable_item_swing_usage": "Block-Trefferanimation aktivieren",
   "visual_settings.viafabricplus.disable_server_pinging": "Server-Ping deaktivieren",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Seitliches rückwärts laufen",
   "visual_settings.viafabricplus.enable_legacy_tablist": "Legacy-Tab-Liste aktivieren",

--- a/src/main/resources/assets/viafabricplus/lang/de_de.json
+++ b/src/main/resources/assets/viafabricplus/lang/de_de.json
@@ -89,7 +89,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Alte Laufanimation",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Verhalten des Schriftarten-Renderers ändern",
   "visual_settings.viafabricplus.enable_sword_blocking": "Schwertblockierung aktivieren",
-  "visual_settings.viafabricplus.enable_block_hit_animation": "Block-Trefferanimation aktivieren",
+  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Block-Trefferanimation aktivieren",
   "visual_settings.viafabricplus.disable_server_pinging": "Server-Ping deaktivieren",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Seitliches rückwärts laufen",
   "visual_settings.viafabricplus.enable_legacy_tablist": "Legacy-Tab-Liste aktivieren",

--- a/src/main/resources/assets/viafabricplus/lang/de_de.json
+++ b/src/main/resources/assets/viafabricplus/lang/de_de.json
@@ -89,7 +89,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Alte Laufanimation",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Verhalten des Schriftarten-Renderers ändern",
   "visual_settings.viafabricplus.enable_sword_blocking": "Schwertblockierung aktivieren",
-  "visual_settings.viafabricplus.enable_item_swing_usage": "Block-Trefferanimation aktivieren",
+  "visual_settings.viafabricplus.swing_hand_on_item_use": "Block-Trefferanimation aktivieren",
   "visual_settings.viafabricplus.disable_server_pinging": "Server-Ping deaktivieren",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Seitliches rückwärts laufen",
   "visual_settings.viafabricplus.enable_legacy_tablist": "Legacy-Tab-Liste aktivieren",

--- a/src/main/resources/assets/viafabricplus/lang/en_us.json
+++ b/src/main/resources/assets/viafabricplus/lang/en_us.json
@@ -91,7 +91,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Old walking animation",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Change Font Renderer behavior",
   "visual_settings.viafabricplus.enable_sword_blocking": "Enable sword animation",
-  "visual_settings.viafabricplus.enable_item_swing_usage": "Enable item swing usage animation",
+  "visual_settings.viafabricplus.enable_item_swing_usage": "Swing hand on item use",
   "visual_settings.viafabricplus.disable_server_pinging": "Disable server pinging",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Sideways backwards walking",
   "visual_settings.viafabricplus.enable_legacy_tablist": "Enable legacy tablist",

--- a/src/main/resources/assets/viafabricplus/lang/en_us.json
+++ b/src/main/resources/assets/viafabricplus/lang/en_us.json
@@ -91,7 +91,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Old walking animation",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Change Font Renderer behavior",
   "visual_settings.viafabricplus.enable_sword_blocking": "Enable sword animation",
-  "visual_settings.viafabricplus.enable_item_swing_usage": "Swing hand on item use",
+  "visual_settings.viafabricplus.swing_hand_on_item_use": "Swing hand on item use",
   "visual_settings.viafabricplus.disable_server_pinging": "Disable server pinging",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Sideways backwards walking",
   "visual_settings.viafabricplus.enable_legacy_tablist": "Enable legacy tablist",

--- a/src/main/resources/assets/viafabricplus/lang/en_us.json
+++ b/src/main/resources/assets/viafabricplus/lang/en_us.json
@@ -91,7 +91,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Old walking animation",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Change Font Renderer behavior",
   "visual_settings.viafabricplus.enable_sword_blocking": "Enable sword animation",
-  "visual_settings.viafabricplus.enable_item_swing_usage": "Enable block hit animation",
+  "visual_settings.viafabricplus.enable_item_swing_usage": "Enable item swing usage animation",
   "visual_settings.viafabricplus.disable_server_pinging": "Disable server pinging",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Sideways backwards walking",
   "visual_settings.viafabricplus.enable_legacy_tablist": "Enable legacy tablist",

--- a/src/main/resources/assets/viafabricplus/lang/en_us.json
+++ b/src/main/resources/assets/viafabricplus/lang/en_us.json
@@ -91,7 +91,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Old walking animation",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Change Font Renderer behavior",
   "visual_settings.viafabricplus.enable_sword_blocking": "Enable sword animation",
-  "visual_settings.viafabricplus.enable_block_hit_animation": "Enable block hit animation",
+  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Enable block hit animation",
   "visual_settings.viafabricplus.disable_server_pinging": "Disable server pinging",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Sideways backwards walking",
   "visual_settings.viafabricplus.enable_legacy_tablist": "Enable legacy tablist",

--- a/src/main/resources/assets/viafabricplus/lang/en_us.json
+++ b/src/main/resources/assets/viafabricplus/lang/en_us.json
@@ -91,7 +91,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Old walking animation",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Change Font Renderer behavior",
   "visual_settings.viafabricplus.enable_sword_blocking": "Enable sword animation",
-  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Enable block hit animation",
+  "visual_settings.viafabricplus.enable_item_swing_usage": "Enable block hit animation",
   "visual_settings.viafabricplus.disable_server_pinging": "Disable server pinging",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Sideways backwards walking",
   "visual_settings.viafabricplus.enable_legacy_tablist": "Enable legacy tablist",

--- a/src/main/resources/assets/viafabricplus/lang/es_ar.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_ar.json
@@ -78,7 +78,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
   "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
-  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Habilitar animación de golpe de bloque",
+  "visual_settings.viafabricplus.enable_item_swing_usage": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus falló al verificar tu sesión! Por favor inicia sesión en una cuenta o desactiva la autenticación de BetaCraft en la configuración de ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/es_ar.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_ar.json
@@ -78,7 +78,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
   "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
-  "visual_settings.viafabricplus.enable_block_hit_animation": "Habilitar animación de golpe de bloque",
+  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus falló al verificar tu sesión! Por favor inicia sesión en una cuenta o desactiva la autenticación de BetaCraft en la configuración de ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/es_ar.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_ar.json
@@ -78,7 +78,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
   "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
-  "visual_settings.viafabricplus.enable_item_swing_usage": "Habilitar animación de golpe de bloque",
+  "visual_settings.viafabricplus.swing_hand_on_item_use": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus falló al verificar tu sesión! Por favor inicia sesión en una cuenta o desactiva la autenticación de BetaCraft en la configuración de ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/es_cl.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_cl.json
@@ -78,7 +78,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
   "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
-  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Habilitar animación de golpe de bloque",
+  "visual_settings.viafabricplus.enable_item_swing_usage": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus falló al verificar tu sesión! Por favor inicia sesión en una cuenta o desactiva la autenticación de BetaCraft en la configuración de ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/es_cl.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_cl.json
@@ -78,7 +78,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
   "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
-  "visual_settings.viafabricplus.enable_block_hit_animation": "Habilitar animación de golpe de bloque",
+  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus falló al verificar tu sesión! Por favor inicia sesión en una cuenta o desactiva la autenticación de BetaCraft en la configuración de ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/es_cl.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_cl.json
@@ -78,7 +78,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
   "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
-  "visual_settings.viafabricplus.enable_item_swing_usage": "Habilitar animación de golpe de bloque",
+  "visual_settings.viafabricplus.swing_hand_on_item_use": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus falló al verificar tu sesión! Por favor inicia sesión en una cuenta o desactiva la autenticación de BetaCraft en la configuración de ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/es_ec.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_ec.json
@@ -78,7 +78,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
   "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
-  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Habilitar animación de golpe de bloque",
+  "visual_settings.viafabricplus.enable_item_swing_usage": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus falló al verificar tu sesión! Por favor inicia sesión en una cuenta o desactiva la autenticación de BetaCraft en la configuración de ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/es_ec.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_ec.json
@@ -78,7 +78,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
   "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
-  "visual_settings.viafabricplus.enable_block_hit_animation": "Habilitar animación de golpe de bloque",
+  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus falló al verificar tu sesión! Por favor inicia sesión en una cuenta o desactiva la autenticación de BetaCraft en la configuración de ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/es_ec.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_ec.json
@@ -78,7 +78,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
   "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
-  "visual_settings.viafabricplus.enable_item_swing_usage": "Habilitar animación de golpe de bloque",
+  "visual_settings.viafabricplus.swing_hand_on_item_use": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus falló al verificar tu sesión! Por favor inicia sesión en una cuenta o desactiva la autenticación de BetaCraft en la configuración de ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/es_es.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_es.json
@@ -78,7 +78,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
   "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
-  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Habilitar animación de golpe de bloque",
+  "visual_settings.viafabricplus.enable_item_swing_usage": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus falló al verificar tu sesión! Por favor inicia sesión en una cuenta o desactiva la autenticación de BetaCraft en la configuración de ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/es_es.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_es.json
@@ -78,7 +78,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
   "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
-  "visual_settings.viafabricplus.enable_block_hit_animation": "Habilitar animación de golpe de bloque",
+  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus falló al verificar tu sesión! Por favor inicia sesión en una cuenta o desactiva la autenticación de BetaCraft en la configuración de ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/es_es.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_es.json
@@ -78,7 +78,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
   "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
-  "visual_settings.viafabricplus.enable_item_swing_usage": "Habilitar animación de golpe de bloque",
+  "visual_settings.viafabricplus.swing_hand_on_item_use": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus falló al verificar tu sesión! Por favor inicia sesión en una cuenta o desactiva la autenticación de BetaCraft en la configuración de ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/es_mx.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_mx.json
@@ -78,7 +78,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
   "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
-  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Habilitar animación de golpe de bloque",
+  "visual_settings.viafabricplus.enable_item_swing_usage": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus falló al verificar tu sesión! Por favor inicia sesión en una cuenta o desactiva la autenticación de BetaCraft en la configuración de ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/es_mx.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_mx.json
@@ -78,7 +78,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
   "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
-  "visual_settings.viafabricplus.enable_block_hit_animation": "Habilitar animación de golpe de bloque",
+  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus falló al verificar tu sesión! Por favor inicia sesión en una cuenta o desactiva la autenticación de BetaCraft en la configuración de ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/es_mx.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_mx.json
@@ -78,7 +78,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
   "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
-  "visual_settings.viafabricplus.enable_item_swing_usage": "Habilitar animación de golpe de bloque",
+  "visual_settings.viafabricplus.swing_hand_on_item_use": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus falló al verificar tu sesión! Por favor inicia sesión en una cuenta o desactiva la autenticación de BetaCraft en la configuración de ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/es_uy.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_uy.json
@@ -78,7 +78,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
   "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
-  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Habilitar animación de golpe de bloque",
+  "visual_settings.viafabricplus.enable_item_swing_usage": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus falló al verificar tu sesión! Por favor inicia sesión en una cuenta o desactiva la autenticación de BetaCraft en la configuración de ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/es_uy.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_uy.json
@@ -78,7 +78,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
   "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
-  "visual_settings.viafabricplus.enable_block_hit_animation": "Habilitar animación de golpe de bloque",
+  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus falló al verificar tu sesión! Por favor inicia sesión en una cuenta o desactiva la autenticación de BetaCraft en la configuración de ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/es_uy.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_uy.json
@@ -78,7 +78,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
   "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
-  "visual_settings.viafabricplus.enable_item_swing_usage": "Habilitar animación de golpe de bloque",
+  "visual_settings.viafabricplus.swing_hand_on_item_use": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus falló al verificar tu sesión! Por favor inicia sesión en una cuenta o desactiva la autenticación de BetaCraft en la configuración de ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/es_ve.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_ve.json
@@ -78,7 +78,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
   "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
-  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Habilitar animación de golpe de bloque",
+  "visual_settings.viafabricplus.enable_item_swing_usage": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus falló al verificar tu sesión! Por favor inicia sesión en una cuenta o desactiva la autenticación de BetaCraft en la configuración de ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/es_ve.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_ve.json
@@ -78,7 +78,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
   "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
-  "visual_settings.viafabricplus.enable_block_hit_animation": "Habilitar animación de golpe de bloque",
+  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus falló al verificar tu sesión! Por favor inicia sesión en una cuenta o desactiva la autenticación de BetaCraft en la configuración de ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/es_ve.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_ve.json
@@ -78,7 +78,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
   "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
-  "visual_settings.viafabricplus.enable_item_swing_usage": "Habilitar animación de golpe de bloque",
+  "visual_settings.viafabricplus.swing_hand_on_item_use": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus falló al verificar tu sesión! Por favor inicia sesión en una cuenta o desactiva la autenticación de BetaCraft en la configuración de ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/hu_hu.json
+++ b/src/main/resources/assets/viafabricplus/lang/hu_hu.json
@@ -76,7 +76,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Régi séta animáció",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Betűkészlet renderelő viselkedésének módosítása",
   "visual_settings.viafabricplus.enable_sword_blocking": "Kard animáció bekapcsolása",
-  "visual_settings.viafabricplus.enable_block_hit_animation": "Blokkolás-ütés animáció bekapcsolása",
+  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Blokkolás-ütés animáció bekapcsolása",
 
   "bedrock.viafabricplus.login": "A böngésződnek meg kellett volna nyílnia.\nKérlek írd be a következő kódot: %s\nEzen képernyő bezárása megszakítja a folyamatot!",
   "authentication.viafabricplus.failed_to_verify_session": "A ViaFabricPlus nem tudta ellenőrizni a munkamenetet! Kérlek jelentkezz be egy Fiókba, vagy kapcsold ki a BetaCraft hitelesítést a ViaFabricPlus Beállításaiban",

--- a/src/main/resources/assets/viafabricplus/lang/hu_hu.json
+++ b/src/main/resources/assets/viafabricplus/lang/hu_hu.json
@@ -76,7 +76,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Régi séta animáció",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Betűkészlet renderelő viselkedésének módosítása",
   "visual_settings.viafabricplus.enable_sword_blocking": "Kard animáció bekapcsolása",
-  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Blokkolás-ütés animáció bekapcsolása",
+  "visual_settings.viafabricplus.enable_item_swing_usage": "Blokkolás-ütés animáció bekapcsolása",
 
   "bedrock.viafabricplus.login": "A böngésződnek meg kellett volna nyílnia.\nKérlek írd be a következő kódot: %s\nEzen képernyő bezárása megszakítja a folyamatot!",
   "authentication.viafabricplus.failed_to_verify_session": "A ViaFabricPlus nem tudta ellenőrizni a munkamenetet! Kérlek jelentkezz be egy Fiókba, vagy kapcsold ki a BetaCraft hitelesítést a ViaFabricPlus Beállításaiban",

--- a/src/main/resources/assets/viafabricplus/lang/hu_hu.json
+++ b/src/main/resources/assets/viafabricplus/lang/hu_hu.json
@@ -76,7 +76,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Régi séta animáció",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Betűkészlet renderelő viselkedésének módosítása",
   "visual_settings.viafabricplus.enable_sword_blocking": "Kard animáció bekapcsolása",
-  "visual_settings.viafabricplus.enable_item_swing_usage": "Blokkolás-ütés animáció bekapcsolása",
+  "visual_settings.viafabricplus.swing_hand_on_item_use": "Blokkolás-ütés animáció bekapcsolása",
 
   "bedrock.viafabricplus.login": "A böngésződnek meg kellett volna nyílnia.\nKérlek írd be a következő kódot: %s\nEzen képernyő bezárása megszakítja a folyamatot!",
   "authentication.viafabricplus.failed_to_verify_session": "A ViaFabricPlus nem tudta ellenőrizni a munkamenetet! Kérlek jelentkezz be egy Fiókba, vagy kapcsold ki a BetaCraft hitelesítést a ViaFabricPlus Beállításaiban",

--- a/src/main/resources/assets/viafabricplus/lang/ko_kr.json
+++ b/src/main/resources/assets/viafabricplus/lang/ko_kr.json
@@ -91,7 +91,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "예전 걷기 에니메이션",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "폰트 렌더링 방식 바꾸기",
   "visual_settings.viafabricplus.enable_sword_blocking": "칼로 막기 허용",
-  "visual_settings.viafabricplus.enable_block_hit_animation": "블럭 치는 에니메이션 허용",
+  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "블럭 치는 에니메이션 허용",
   "visual_settings.viafabricplus.disable_server_pinging": "서버 핑 비활성화",
   "visual_settings.viafabricplus.sideways_backwards_walking": "옆과 뒤로 걷기",
   "visual_settings.viafabricplus.enable_legacy_tablist": "레거시 탭 리스트 허용",

--- a/src/main/resources/assets/viafabricplus/lang/ko_kr.json
+++ b/src/main/resources/assets/viafabricplus/lang/ko_kr.json
@@ -91,7 +91,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "예전 걷기 에니메이션",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "폰트 렌더링 방식 바꾸기",
   "visual_settings.viafabricplus.enable_sword_blocking": "칼로 막기 허용",
-  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "블럭 치는 에니메이션 허용",
+  "visual_settings.viafabricplus.enable_item_swing_usage": "블럭 치는 에니메이션 허용",
   "visual_settings.viafabricplus.disable_server_pinging": "서버 핑 비활성화",
   "visual_settings.viafabricplus.sideways_backwards_walking": "옆과 뒤로 걷기",
   "visual_settings.viafabricplus.enable_legacy_tablist": "레거시 탭 리스트 허용",

--- a/src/main/resources/assets/viafabricplus/lang/ko_kr.json
+++ b/src/main/resources/assets/viafabricplus/lang/ko_kr.json
@@ -91,7 +91,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "예전 걷기 에니메이션",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "폰트 렌더링 방식 바꾸기",
   "visual_settings.viafabricplus.enable_sword_blocking": "칼로 막기 허용",
-  "visual_settings.viafabricplus.enable_item_swing_usage": "블럭 치는 에니메이션 허용",
+  "visual_settings.viafabricplus.swing_hand_on_item_use": "블럭 치는 에니메이션 허용",
   "visual_settings.viafabricplus.disable_server_pinging": "서버 핑 비활성화",
   "visual_settings.viafabricplus.sideways_backwards_walking": "옆과 뒤로 걷기",
   "visual_settings.viafabricplus.enable_legacy_tablist": "레거시 탭 리스트 허용",

--- a/src/main/resources/assets/viafabricplus/lang/lb_lu.json
+++ b/src/main/resources/assets/viafabricplus/lang/lb_lu.json
@@ -82,7 +82,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Aal Laafanimatioun",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Verhaalen vum Schreftarten-Renderer änneren",
   "visual_settings.viafabricplus.enable_sword_blocking": "Schwertblockeierung aktivieieren",
-  "visual_settings.viafabricplus.enable_block_hit_animation": "Block-Trefferanimation aktiveieren",
+  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Block-Trefferanimation aktiveieren",
   "visual_settings.viafabricplus.disable_server_pinging": "Server-Ping deaktiveieren",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Säitlicht hannerzech laafen",
   "visual_settings.viafabricplus.enable_legacy_tablist": "Legacy-Tab-Lescht aktiveieren",

--- a/src/main/resources/assets/viafabricplus/lang/lb_lu.json
+++ b/src/main/resources/assets/viafabricplus/lang/lb_lu.json
@@ -82,7 +82,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Aal Laafanimatioun",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Verhaalen vum Schreftarten-Renderer änneren",
   "visual_settings.viafabricplus.enable_sword_blocking": "Schwertblockeierung aktivieieren",
-  "visual_settings.viafabricplus.enable_item_swing_usage": "Block-Trefferanimation aktiveieren",
+  "visual_settings.viafabricplus.swing_hand_on_item_use": "Block-Trefferanimation aktiveieren",
   "visual_settings.viafabricplus.disable_server_pinging": "Server-Ping deaktiveieren",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Säitlicht hannerzech laafen",
   "visual_settings.viafabricplus.enable_legacy_tablist": "Legacy-Tab-Lescht aktiveieren",

--- a/src/main/resources/assets/viafabricplus/lang/lb_lu.json
+++ b/src/main/resources/assets/viafabricplus/lang/lb_lu.json
@@ -82,7 +82,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Aal Laafanimatioun",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Verhaalen vum Schreftarten-Renderer änneren",
   "visual_settings.viafabricplus.enable_sword_blocking": "Schwertblockeierung aktivieieren",
-  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Block-Trefferanimation aktiveieren",
+  "visual_settings.viafabricplus.enable_item_swing_usage": "Block-Trefferanimation aktiveieren",
   "visual_settings.viafabricplus.disable_server_pinging": "Server-Ping deaktiveieren",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Säitlicht hannerzech laafen",
   "visual_settings.viafabricplus.enable_legacy_tablist": "Legacy-Tab-Lescht aktiveieren",

--- a/src/main/resources/assets/viafabricplus/lang/pl_pl.json
+++ b/src/main/resources/assets/viafabricplus/lang/pl_pl.json
@@ -94,7 +94,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Stara animacja chodzenia",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Zmień sposób renderowania czcionek",
   "visual_settings.viafabricplus.enable_sword_blocking": "Włącz blokowanie mieczem",
-  "visual_settings.viafabricplus.enable_block_hit_animation": "Włącz animację niszczenia bloków 1.7",
+  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Włącz animację niszczenia bloków 1.7",
   "visual_settings.viafabricplus.disable_server_pinging": "Wyłącz pingowanie serwerów",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Chodzenie do tyłu na boki",
   "visual_settings.viafabricplus.enable_legacy_tablist": "Włącz starą listę graczy",

--- a/src/main/resources/assets/viafabricplus/lang/pl_pl.json
+++ b/src/main/resources/assets/viafabricplus/lang/pl_pl.json
@@ -94,7 +94,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Stara animacja chodzenia",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Zmień sposób renderowania czcionek",
   "visual_settings.viafabricplus.enable_sword_blocking": "Włącz blokowanie mieczem",
-  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Włącz animację niszczenia bloków 1.7",
+  "visual_settings.viafabricplus.enable_item_swing_usage": "Włącz animację niszczenia bloków 1.7",
   "visual_settings.viafabricplus.disable_server_pinging": "Wyłącz pingowanie serwerów",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Chodzenie do tyłu na boki",
   "visual_settings.viafabricplus.enable_legacy_tablist": "Włącz starą listę graczy",

--- a/src/main/resources/assets/viafabricplus/lang/pl_pl.json
+++ b/src/main/resources/assets/viafabricplus/lang/pl_pl.json
@@ -94,7 +94,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Stara animacja chodzenia",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Zmień sposób renderowania czcionek",
   "visual_settings.viafabricplus.enable_sword_blocking": "Włącz blokowanie mieczem",
-  "visual_settings.viafabricplus.enable_item_swing_usage": "Włącz animację niszczenia bloków 1.7",
+  "visual_settings.viafabricplus.swing_hand_on_item_use": "Włącz animację niszczenia bloków 1.7",
   "visual_settings.viafabricplus.disable_server_pinging": "Wyłącz pingowanie serwerów",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Chodzenie do tyłu na boki",
   "visual_settings.viafabricplus.enable_legacy_tablist": "Włącz starą listę graczy",

--- a/src/main/resources/assets/viafabricplus/lang/ru_ru.json
+++ b/src/main/resources/assets/viafabricplus/lang/ru_ru.json
@@ -83,7 +83,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Старая анимация ходьбы",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Старый шрифт",
   "visual_settings.viafabricplus.enable_sword_blocking": "Анимация меча",
-  "visual_settings.viafabricplus.enable_item_swing_usage": "Парирование атак из версии 1.7",
+  "visual_settings.viafabricplus.swing_hand_on_item_use": "Парирование атак из версии 1.7",
   "visual_settings.viafabricplus.disable_server_pinging": "Не проверять соединение",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Старая походка спиной",
   "visual_settings.viafabricplus.enable_legacy_tablist": "Старый список игроков",

--- a/src/main/resources/assets/viafabricplus/lang/ru_ru.json
+++ b/src/main/resources/assets/viafabricplus/lang/ru_ru.json
@@ -83,7 +83,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Старая анимация ходьбы",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Старый шрифт",
   "visual_settings.viafabricplus.enable_sword_blocking": "Анимация меча",
-  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Парирование атак из версии 1.7",
+  "visual_settings.viafabricplus.enable_item_swing_usage": "Парирование атак из версии 1.7",
   "visual_settings.viafabricplus.disable_server_pinging": "Не проверять соединение",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Старая походка спиной",
   "visual_settings.viafabricplus.enable_legacy_tablist": "Старый список игроков",

--- a/src/main/resources/assets/viafabricplus/lang/ru_ru.json
+++ b/src/main/resources/assets/viafabricplus/lang/ru_ru.json
@@ -83,7 +83,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Старая анимация ходьбы",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Старый шрифт",
   "visual_settings.viafabricplus.enable_sword_blocking": "Анимация меча",
-  "visual_settings.viafabricplus.enable_block_hit_animation": "Парирование атак из версии 1.7",
+  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Парирование атак из версии 1.7",
   "visual_settings.viafabricplus.disable_server_pinging": "Не проверять соединение",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Старая походка спиной",
   "visual_settings.viafabricplus.enable_legacy_tablist": "Старый список игроков",

--- a/src/main/resources/assets/viafabricplus/lang/tr_tr.json
+++ b/src/main/resources/assets/viafabricplus/lang/tr_tr.json
@@ -90,7 +90,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Eski Yürüyüş Animasyonu",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Yazı Tipi Oluşturucu Davranışını Değiştirme",
   "visual_settings.viafabricplus.enable_sword_blocking": "Kılıç Animasyonunu Aç",
-  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Blok Hit Animasyonunu Aç",
+  "visual_settings.viafabricplus.enable_item_swing_usage": "Blok Hit Animasyonunu Aç",
   "visual_settings.viafabricplus.disable_server_pinging": "Veri Gönderimini Kapat",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Yana Doğru Geri Geri Yürüme",
   "visual_settings.viafabricplus.enable_legacy_tablist": "Eski Tablist'i Aç",

--- a/src/main/resources/assets/viafabricplus/lang/tr_tr.json
+++ b/src/main/resources/assets/viafabricplus/lang/tr_tr.json
@@ -90,7 +90,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Eski Yürüyüş Animasyonu",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Yazı Tipi Oluşturucu Davranışını Değiştirme",
   "visual_settings.viafabricplus.enable_sword_blocking": "Kılıç Animasyonunu Aç",
-  "visual_settings.viafabricplus.enable_block_hit_animation": "Blok Hit Animasyonunu Aç",
+  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Blok Hit Animasyonunu Aç",
   "visual_settings.viafabricplus.disable_server_pinging": "Veri Gönderimini Kapat",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Yana Doğru Geri Geri Yürüme",
   "visual_settings.viafabricplus.enable_legacy_tablist": "Eski Tablist'i Aç",

--- a/src/main/resources/assets/viafabricplus/lang/tr_tr.json
+++ b/src/main/resources/assets/viafabricplus/lang/tr_tr.json
@@ -90,7 +90,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Eski Yürüyüş Animasyonu",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Yazı Tipi Oluşturucu Davranışını Değiştirme",
   "visual_settings.viafabricplus.enable_sword_blocking": "Kılıç Animasyonunu Aç",
-  "visual_settings.viafabricplus.enable_item_swing_usage": "Blok Hit Animasyonunu Aç",
+  "visual_settings.viafabricplus.swing_hand_on_item_use": "Blok Hit Animasyonunu Aç",
   "visual_settings.viafabricplus.disable_server_pinging": "Veri Gönderimini Kapat",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Yana Doğru Geri Geri Yürüme",
   "visual_settings.viafabricplus.enable_legacy_tablist": "Eski Tablist'i Aç",

--- a/src/main/resources/assets/viafabricplus/lang/uk_ua.json
+++ b/src/main/resources/assets/viafabricplus/lang/uk_ua.json
@@ -76,7 +76,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Стара анімація ходьби",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Змінити поведінку рендерингу шрифта",
   "visual_settings.viafabricplus.enable_sword_blocking": "Увімкнути блокування мечем",
-  "visual_settings.viafabricplus.enable_item_swing_usage": "Ввімкнути анімацію удару блоку 1.7",
+  "visual_settings.viafabricplus.swing_hand_on_item_use": "Ввімкнути анімацію удару блоку 1.7",
 
   "bedrock.viafabricplus.login": "Ваш браузер мав відкритися.\nБудь ласка, введіть наступний код: %s\nЯкщо закрити цей екран, процес буде скасовано!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus не зміг підтвредити вашу сессію! Будь ласка увійдіть у Ваш аккаунт чи вимкніть аутентифікацію BetaCraft в налаштуваннях ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/uk_ua.json
+++ b/src/main/resources/assets/viafabricplus/lang/uk_ua.json
@@ -76,7 +76,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Стара анімація ходьби",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Змінити поведінку рендерингу шрифта",
   "visual_settings.viafabricplus.enable_sword_blocking": "Увімкнути блокування мечем",
-  "visual_settings.viafabricplus.enable_block_hit_animation": "Ввімкнути анімацію удару блоку 1.7",
+  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Ввімкнути анімацію удару блоку 1.7",
 
   "bedrock.viafabricplus.login": "Ваш браузер мав відкритися.\nБудь ласка, введіть наступний код: %s\nЯкщо закрити цей екран, процес буде скасовано!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus не зміг підтвредити вашу сессію! Будь ласка увійдіть у Ваш аккаунт чи вимкніть аутентифікацію BetaCraft в налаштуваннях ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/uk_ua.json
+++ b/src/main/resources/assets/viafabricplus/lang/uk_ua.json
@@ -76,7 +76,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "Стара анімація ходьби",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Змінити поведінку рендерингу шрифта",
   "visual_settings.viafabricplus.enable_sword_blocking": "Увімкнути блокування мечем",
-  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "Ввімкнути анімацію удару блоку 1.7",
+  "visual_settings.viafabricplus.enable_item_swing_usage": "Ввімкнути анімацію удару блоку 1.7",
 
   "bedrock.viafabricplus.login": "Ваш браузер мав відкритися.\nБудь ласка, введіть наступний код: %s\nЯкщо закрити цей екран, процес буде скасовано!",
   "authentication.viafabricplus.failed_to_verify_session": "ViaFabricPlus не зміг підтвредити вашу сессію! Будь ласка увійдіть у Ваш аккаунт чи вимкніть аутентифікацію BetaCraft в налаштуваннях ViaFabricPlus",

--- a/src/main/resources/assets/viafabricplus/lang/zh_cn.json
+++ b/src/main/resources/assets/viafabricplus/lang/zh_cn.json
@@ -91,7 +91,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "旧版行走动画",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "更改字体渲染器行为",
   "visual_settings.viafabricplus.enable_sword_blocking": "启用剑动画",
-  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "启用格挡命中动画",
+  "visual_settings.viafabricplus.enable_item_swing_usage": "启用格挡命中动画",
   "visual_settings.viafabricplus.disable_server_pinging": "禁用服务器Ping",
   "visual_settings.viafabricplus.sideways_backwards_walking": "侧身后退行走",
   "visual_settings.viafabricplus.enable_legacy_tablist": "启用旧版Tab列表",

--- a/src/main/resources/assets/viafabricplus/lang/zh_cn.json
+++ b/src/main/resources/assets/viafabricplus/lang/zh_cn.json
@@ -91,7 +91,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "旧版行走动画",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "更改字体渲染器行为",
   "visual_settings.viafabricplus.enable_sword_blocking": "启用剑动画",
-  "visual_settings.viafabricplus.enable_item_swing_usage": "启用格挡命中动画",
+  "visual_settings.viafabricplus.swing_hand_on_item_use": "启用格挡命中动画",
   "visual_settings.viafabricplus.disable_server_pinging": "禁用服务器Ping",
   "visual_settings.viafabricplus.sideways_backwards_walking": "侧身后退行走",
   "visual_settings.viafabricplus.enable_legacy_tablist": "启用旧版Tab列表",

--- a/src/main/resources/assets/viafabricplus/lang/zh_cn.json
+++ b/src/main/resources/assets/viafabricplus/lang/zh_cn.json
@@ -91,7 +91,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "旧版行走动画",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "更改字体渲染器行为",
   "visual_settings.viafabricplus.enable_sword_blocking": "启用剑动画",
-  "visual_settings.viafabricplus.enable_block_hit_animation": "启用格挡命中动画",
+  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "启用格挡命中动画",
   "visual_settings.viafabricplus.disable_server_pinging": "禁用服务器Ping",
   "visual_settings.viafabricplus.sideways_backwards_walking": "侧身后退行走",
   "visual_settings.viafabricplus.enable_legacy_tablist": "启用旧版Tab列表",

--- a/src/main/resources/assets/viafabricplus/lang/zh_hk.json
+++ b/src/main/resources/assets/viafabricplus/lang/zh_hk.json
@@ -90,7 +90,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "舊版行走動畫",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "改變字體渲染嘅行為",
   "visual_settings.viafabricplus.enable_sword_blocking": "啟用 1.8 劍阻擋動畫",
-  "visual_settings.viafabricplus.enable_item_swing_usage": "啟用 1.7 阻擋攻擊動畫",
+  "visual_settings.viafabricplus.swing_hand_on_item_use": "啟用 1.7 阻擋攻擊動畫",
   "visual_settings.viafabricplus.disable_server_pinging": "禁用伺服器 pinging",
   "visual_settings.viafabricplus.sideways_backwards_walking": "側身倒退行走",
   "visual_settings.viafabricplus.enable_legacy_tablist": "啟用舊版 Tab 列表",

--- a/src/main/resources/assets/viafabricplus/lang/zh_hk.json
+++ b/src/main/resources/assets/viafabricplus/lang/zh_hk.json
@@ -90,7 +90,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "舊版行走動畫",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "改變字體渲染嘅行為",
   "visual_settings.viafabricplus.enable_sword_blocking": "啟用 1.8 劍阻擋動畫",
-  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "啟用 1.7 阻擋攻擊動畫",
+  "visual_settings.viafabricplus.enable_item_swing_usage": "啟用 1.7 阻擋攻擊動畫",
   "visual_settings.viafabricplus.disable_server_pinging": "禁用伺服器 pinging",
   "visual_settings.viafabricplus.sideways_backwards_walking": "側身倒退行走",
   "visual_settings.viafabricplus.enable_legacy_tablist": "啟用舊版 Tab 列表",

--- a/src/main/resources/assets/viafabricplus/lang/zh_hk.json
+++ b/src/main/resources/assets/viafabricplus/lang/zh_hk.json
@@ -90,7 +90,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "舊版行走動畫",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "改變字體渲染嘅行為",
   "visual_settings.viafabricplus.enable_sword_blocking": "啟用 1.8 劍阻擋動畫",
-  "visual_settings.viafabricplus.enable_block_hit_animation": "啟用 1.7 阻擋攻擊動畫",
+  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "啟用 1.7 阻擋攻擊動畫",
   "visual_settings.viafabricplus.disable_server_pinging": "禁用伺服器 pinging",
   "visual_settings.viafabricplus.sideways_backwards_walking": "側身倒退行走",
   "visual_settings.viafabricplus.enable_legacy_tablist": "啟用舊版 Tab 列表",

--- a/src/main/resources/assets/viafabricplus/lang/zh_tw.json
+++ b/src/main/resources/assets/viafabricplus/lang/zh_tw.json
@@ -91,7 +91,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "舊版行走動畫",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "變更字型渲染器行為",
   "visual_settings.viafabricplus.enable_sword_blocking": "啟用 1.8 劍格擋動畫",
-  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "啟用 1.7 格擋攻擊動畫",
+  "visual_settings.viafabricplus.enable_item_swing_usage": "啟用 1.7 格擋攻擊動畫",
   "visual_settings.viafabricplus.disable_server_pinging": "停用伺服器 Ping",
   "visual_settings.viafabricplus.sideways_backwards_walking": "側身倒退行走",
   "visual_settings.viafabricplus.enable_legacy_tablist": "啟用舊版 Tab 清單",

--- a/src/main/resources/assets/viafabricplus/lang/zh_tw.json
+++ b/src/main/resources/assets/viafabricplus/lang/zh_tw.json
@@ -91,7 +91,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "舊版行走動畫",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "變更字型渲染器行為",
   "visual_settings.viafabricplus.enable_sword_blocking": "啟用 1.8 劍格擋動畫",
-  "visual_settings.viafabricplus.enable_block_hit_animation": "啟用 1.7 格擋攻擊動畫",
+  "visual_settings.viafabricplus.enable_enable_item_swing_usage": "啟用 1.7 格擋攻擊動畫",
   "visual_settings.viafabricplus.disable_server_pinging": "停用伺服器 Ping",
   "visual_settings.viafabricplus.sideways_backwards_walking": "側身倒退行走",
   "visual_settings.viafabricplus.enable_legacy_tablist": "啟用舊版 Tab 清單",

--- a/src/main/resources/assets/viafabricplus/lang/zh_tw.json
+++ b/src/main/resources/assets/viafabricplus/lang/zh_tw.json
@@ -91,7 +91,7 @@
   "visual_settings.viafabricplus.old_walking_animation": "舊版行走動畫",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "變更字型渲染器行為",
   "visual_settings.viafabricplus.enable_sword_blocking": "啟用 1.8 劍格擋動畫",
-  "visual_settings.viafabricplus.enable_item_swing_usage": "啟用 1.7 格擋攻擊動畫",
+  "visual_settings.viafabricplus.swing_hand_on_item_use": "啟用 1.7 格擋攻擊動畫",
   "visual_settings.viafabricplus.disable_server_pinging": "停用伺服器 Ping",
   "visual_settings.viafabricplus.sideways_backwards_walking": "側身倒退行走",
   "visual_settings.viafabricplus.enable_legacy_tablist": "啟用舊版 Tab 清單",


### PR DESCRIPTION
In 1.7.x and below, like with the sword blocking animation, you could use & swing the item on the ground with food/potions also. 
Renamed the field to be appropriate also.