### PR TITLE
Negative Potions Fix

### DIFF
--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/MixinStatusEffect.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/MixinStatusEffect.java
@@ -23,17 +23,20 @@ import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import de.florianmichael.viafabricplus.protocoltranslator.ProtocolTranslator;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.util.math.MathHelper;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(StatusEffectInstance.class)
-public class MixinStatusEffect {
+public abstract class MixinStatusEffect {
 
-    @ModifyArg(method = "<init>(Lnet/minecraft/registry/entry/RegistryEntry;IIZZZLnet/minecraft/entity/effect/StatusEffectInstance;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/MathHelper;clamp(III)I"), index = 1)
-    public int clamp(int min) {
-        return ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_20_3) ? -255 : 0;
+    @Redirect(method = "<init>(Lnet/minecraft/registry/entry/RegistryEntry;IIZZZLnet/minecraft/entity/effect/StatusEffectInstance;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/MathHelper;clamp(III)I"))
+    private int dontClampValue(int value, int min, int max) {
+        if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_20_3)) {
+            return value;
+        } else {
+            return MathHelper.clamp(value, min, max);
+        }
     }
+
 }

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/MixinStatusEffect.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/MixinStatusEffect.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of ViaFabricPlus - https://github.com/FlorianMichael/ViaFabricPlus
+ * Copyright (C) 2021-2024 FlorianMichael/EnZaXD <florian.michael07@gmail.com> and RK_01/RaphiMC
+ * Copyright (C) 2023-2024 contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.florianmichael.viafabricplus.injection.mixin.fixes.minecraft;
+
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import de.florianmichael.viafabricplus.protocoltranslator.ProtocolTranslator;
+import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.util.math.MathHelper;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(StatusEffectInstance.class)
+public class MixinStatusEffect {
+    @Shadow @Final public static int MIN_AMPLIFIER = ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_20_3) ? -255 : 0;
+
+    @Redirect(method = "<init>(Lnet/minecraft/registry/entry/RegistryEntry;IIZZZLnet/minecraft/entity/effect/StatusEffectInstance;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/MathHelper;clamp(III)I"))
+    public int clamp(int value, int min, int max) {
+        return ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_20_3) ? MathHelper.clamp(value, -255, 255) : MathHelper.clamp(value, 0, 255);
+    }
+}

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/MixinStatusEffect.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/MixinStatusEffect.java
@@ -31,10 +31,9 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(StatusEffectInstance.class)
 public class MixinStatusEffect {
-    @Shadow @Final public static int MIN_AMPLIFIER = ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_20_3) ? -255 : 0;
 
-    @Redirect(method = "<init>(Lnet/minecraft/registry/entry/RegistryEntry;IIZZZLnet/minecraft/entity/effect/StatusEffectInstance;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/MathHelper;clamp(III)I"))
-    public int clamp(int value, int min, int max) {
-        return ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_20_3) ? MathHelper.clamp(value, -255, 255) : MathHelper.clamp(value, 0, 255);
+    @ModifyArg(method = "<init>(Lnet/minecraft/registry/entry/RegistryEntry;IIZZZLnet/minecraft/entity/effect/StatusEffectInstance;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/MathHelper;clamp(III)I"), index = 1)
+    public int clamp(int min) {
+        return ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_20_3) ? -255 : 0;
     }
 }

--- a/src/main/resources/viafabricplus.mixins.json
+++ b/src/main/resources/viafabricplus.mixins.json
@@ -61,6 +61,7 @@
     "fixes.minecraft.MixinServerAddress",
     "fixes.minecraft.MixinServerResourcePackLoader_4",
     "fixes.minecraft.MixinStaticSound",
+    "fixes.minecraft.MixinStatusEffect",
     "fixes.minecraft.MixinStringHelper",
     "fixes.minecraft.MixinTextRenderer",
     "fixes.minecraft.MixinTextRenderer_Drawer",


### PR DESCRIPTION
Negative amplifier potion effects were removed in 1.20.5+ causing some problems playing on older versions such as servers that use negative levitation for a more customizable fall speed, but instead you'll float normally without because the client clamps potion amplifiers.  This ofc fixes that problem when playing on 1.20.4> servers.