### PR TITLE
Fix ItemStack equals check in tickActiveItemStack 

### DIFF
--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/entity/MixinLivingEntity.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/entity/MixinLivingEntity.java
@@ -231,6 +231,15 @@ public abstract class MixinLivingEntity extends Entity {
         }
     }
 
+    @Redirect(method = "tickActiveItemStack", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;areItemsEqual(Lnet/minecraft/item/ItemStack;Lnet/minecraft/item/ItemStack;)Z"))
+    private boolean replaceItemStackEqualsCheck(ItemStack left, ItemStack right) {
+        if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_8)) {
+            return left == right;
+        } else {
+            return ItemStack.areItemsEqual(left, right);
+        }
+    }
+
     @ModifyConstant(method = "tickMovement", constant = @Constant(doubleValue = 0.003D))
     private double modifyVelocityZero(final double constant) {
         if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_8)) {

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/entity/MixinLivingEntity.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/entity/MixinLivingEntity.java
@@ -153,6 +153,15 @@ public abstract class MixinLivingEntity extends Entity {
         return ProtocolTranslator.getTargetVersion().newerThan(ProtocolVersion.v1_14_4) && instance.hasVehicle();
     }
 
+    @Redirect(method = "tickActiveItemStack", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;areItemsEqual(Lnet/minecraft/item/ItemStack;Lnet/minecraft/item/ItemStack;)Z"))
+    private boolean replaceItemStackEqualsCheck(ItemStack left, ItemStack right) {
+        if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_14_3)) {
+            return left == right;
+        } else {
+            return ItemStack.areItemsEqual(left, right);
+        }
+    }
+
     @Redirect(method = "travelMidAir", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;isChunkLoaded(Lnet/minecraft/util/math/BlockPos;)Z"))
     private boolean modifyLoadedCheck(World instance, BlockPos blockPos) {
         if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_13_2)) {
@@ -228,15 +237,6 @@ public abstract class MixinLivingEntity extends Entity {
     private void removeShieldSlotPreference(ItemStack stack, CallbackInfoReturnable<EquipmentSlot> cir) {
         if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_9_3) && stack.isOf(Items.SHIELD)) {
             cir.setReturnValue(EquipmentSlot.MAINHAND);
-        }
-    }
-
-    @Redirect(method = "tickActiveItemStack", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;areItemsEqual(Lnet/minecraft/item/ItemStack;Lnet/minecraft/item/ItemStack;)Z"))
-    private boolean replaceItemStackEqualsCheck(ItemStack left, ItemStack right) {
-        if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_8)) {
-            return left == right;
-        } else {
-            return ItemStack.areItemsEqual(left, right);
         }
     }
 


### PR DESCRIPTION
Change the equals logic to be as it was in 1.14.3 and below inside of LivingEntity#tickActiveItemStack, where it directly checked if the stacks were equal, and not only the item like in 1.14.4+. This fixes #495