### PR TITLE
Add toggle to always render crosshair in thirdperson in <=1.8.x

### DIFF
--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/screen/hud/MixinInGameHud.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/screen/hud/MixinInGameHud.java
@@ -24,6 +24,7 @@ import com.llamalad7.mixinextras.sugar.Local;
 import de.florianmichael.viafabricplus.settings.impl.VisualSettings;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.hud.InGameHud;
+import net.minecraft.client.option.Perspective;
 import net.minecraft.entity.LivingEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
@@ -31,6 +32,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
@@ -40,6 +42,15 @@ public abstract class MixinInGameHud {
 
     @Unique
     private static final int viaFabricPlus$ARMOR_ICON_WIDTH = 8;
+
+    @Redirect(method = "renderCrosshair", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/option/Perspective;isFirstPerson()Z"))
+    private boolean alwaysRenderCrosshair(Perspective instance) {
+        if (VisualSettings.global().alwaysRenderCrosshair.isEnabled()) {
+            return true;
+        } else {
+            return instance.isFirstPerson();
+        }
+    }
 
     @Inject(method = {"renderMountJumpBar", "renderMountHealth"}, at = @At("HEAD"), cancellable = true)
     private void removeMountJumpBar(CallbackInfo ci) {

--- a/src/main/java/de/florianmichael/viafabricplus/settings/impl/VisualSettings.java
+++ b/src/main/java/de/florianmichael/viafabricplus/settings/impl/VisualSettings.java
@@ -78,6 +78,7 @@ public class VisualSettings extends SettingGroup {
     public final VersionedBooleanSetting hideCraftingRecipeBook = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.hide_crafting_recipe_book"), VersionRange.andOlder(ProtocolVersion.v1_11_1));
 
     // 1.9 -> 1.8.x
+    public final VersionedBooleanSetting alwaysRenderCrosshair = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.always_render_crosshair"), VersionRange.andOlder(ProtocolVersion.v1_8));
     public final VersionedBooleanSetting emulateArmorHud = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.emulate_armor_hud"), VersionRange.andOlder(ProtocolVersion.v1_8));
     public final VersionedBooleanSetting hideModernCommandBlockScreenFeatures = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.hide_modern_command_block_screen_features"), VersionRange.andOlder(ProtocolVersion.v1_8));
     public final VersionedBooleanSetting enableSwordBlocking = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.enable_sword_blocking"), VersionRange.andOlder(ProtocolVersion.v1_8));

--- a/src/main/resources/assets/viafabricplus/lang/en_us.json
+++ b/src/main/resources/assets/viafabricplus/lang/en_us.json
@@ -88,6 +88,7 @@
   "visual_settings.viafabricplus.hide_signature_indicator": "Hide signature indicator",
   "visual_settings.viafabricplus.hide_download_terrain_screen_transition_effects": "Hide download terrain screen transition effects",
   "visual_settings.viafabricplus.replace_petrified_oak_slab": "Replace petrified oak slab texture with the 'unknown' texture",
+  "visual_settings.viafabricplus.always_render_crosshair": "Always Render Crosshair",
   "visual_settings.viafabricplus.emulate_armor_hud": "Emulate Armor HUD",
   "visual_settings.viafabricplus.hide_modern_command_block_screen_features": "Hide modern command block screen features",
   "visual_settings.viafabricplus.replace_hurt_sound_with_oof_sound": "Replace hurt sound with OOF sound",


### PR DESCRIPTION
Adds a toggle/code to always render crosshair in different perspectives in versions <=1.8.x

I use this to align my self sometimes in thirdperson and noticed that VFP didn't have this, so I decided to add it.