### PR TITLE
Fix inaccurate Y value for <=1.13.2, Fixes #225

### DIFF
--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/entity/MixinEntity.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/entity/MixinEntity.java
@@ -128,7 +128,7 @@ public abstract class MixinEntity implements IEntity {
                 }
 
                 if (vec3d2.horizontalLengthSquared() > adjustedMovement.horizontalLengthSquared()) {
-                    adjustedMovement = vec3d2.add(Entity.adjustMovementForCollisions(thiz, new Vec3d(0D, -vec3d2.y + movement.y, 0D), box.offset(vec3d2), this.getWorld(), collisions));
+                    adjustedMovement = vec3d2.add(Entity.adjustMovementForCollisions(thiz, new Vec3d(0D, -vec3d2.y + (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_13_2) ? 0 : movement.y), 0D), box.offset(vec3d2), this.getWorld(), collisions));
                 }
             }
 


### PR DESCRIPTION
Fixes an inaccuracy in MixinEntity#use1_20_6StepCollisionCalculation, which fixes #225 