### PR TITLE
Fix Fishing Rod Usage

### DIFF
--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinFishingRodItem.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinFishingRodItem.java
@@ -37,7 +37,7 @@ public abstract class MixinFishingRodItem {
     @Inject(method = "use", at = @At("RETURN"))
     private void swingHand(World world, PlayerEntity user, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
         if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_14_4)) {
-            user.swingHand(hand);
+            user.swingHand(hand, false);
         }
     }
 


### PR DESCRIPTION
Fixes broken usage of the rod, where it wasn't working on Hypixel in 1.12/1.8.

After looking at the code, it was using the wrong method compared to what is done in 1.14.4 and below, which this fixes.

Should also fix #625