### PR TITLE
Refactor "enableSwordAnimation" to "swordBlockingAnimation"

### DIFF
--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinFishingRodItem.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinFishingRodItem.java
@@ -37,7 +37,7 @@ public abstract class MixinFishingRodItem {
     @Inject(method = "use", at = @At("RETURN"))
     private void swingHand(World world, PlayerEntity user, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
         if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_14_4)) {
-            user.swingHand(hand);
+            user.swingHand(hand, false);
         }
     }
 

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinFishingRodItem.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinFishingRodItem.java
@@ -37,7 +37,7 @@ public abstract class MixinFishingRodItem {
     @Inject(method = "use", at = @At("RETURN"))
     private void swingHand(World world, PlayerEntity user, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
         if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_14_4)) {
-            user.swingHand(hand, false);
+            user.swingHand(hand);
         }
     }
 

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/item/MixinHeldItemRenderer.java
@@ -26,6 +26,7 @@ import net.minecraft.client.render.item.HeldItemRenderer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.ShieldItem;
 import net.minecraft.util.Arm;
 import net.minecraft.util.Hand;
 import net.minecraft.util.math.RotationAxis;
@@ -47,20 +48,18 @@ public abstract class MixinHeldItemRenderer {
             slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getUseAction()Lnet/minecraft/item/consume/UseAction;")),
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;applyEquipOffset(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/Arm;F)V", ordinal = 2, shift = At.Shift.AFTER))
     private void transformSwordBlockingPosition(AbstractClientPlayerEntity player, float tickDelta, float pitch, Hand hand, float swingProgress, ItemStack item, float equipProgress, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo ci) {
-        if (!VisualSettings.global().enableSwordBlocking.isEnabled()) {
-            return;
+        if (VisualSettings.global().swordBlockingAnimation.isEnabled()) {
+            final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
+            final int direction = arm == Arm.RIGHT ? 1 : -1;
+            viaFabricPlus$applySwingOffset(player, hand, swingProgress, matrices);
+            if (!(item.getItem() instanceof ShieldItem)) {
+                // Values stripped from early 1.9 snapshots, 15w33b specifically, which is the version prior to them removing sword blocking
+                matrices.translate(direction * -0.14142136F, 0.08F, 0.14142136F);
+                matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(-102.25F));
+                matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(direction * 13.365F));
+                matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(direction * 78.05F));
+            }
         }
-
-        final Arm arm = hand == Hand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
-        final int direction = arm == Arm.RIGHT ? 1 : -1;
-
-        viaFabricPlus$applySwingOffset(player, hand, swingProgress, matrices);
-
-        // Values stripped from early 1.9 snapshots, 15w33b specifically, which is the version prior to them removing sword blocking
-        matrices.translate(direction * -0.14142136F, 0.08F, 0.14142136F);
-        matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(-102.25F));
-        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(direction * 13.365F));
-        matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(direction * 78.05F));
     }
 
     @Inject(method = "renderFirstPersonItem",

--- a/src/main/java/de/florianmichael/viafabricplus/settings/impl/VisualSettings.java
+++ b/src/main/java/de/florianmichael/viafabricplus/settings/impl/VisualSettings.java
@@ -81,7 +81,7 @@ public class VisualSettings extends SettingGroup {
     public final VersionedBooleanSetting alwaysRenderCrosshair = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.always_render_crosshair"), VersionRange.andOlder(ProtocolVersion.v1_8));
     public final VersionedBooleanSetting emulateArmorHud = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.emulate_armor_hud"), VersionRange.andOlder(ProtocolVersion.v1_8));
     public final VersionedBooleanSetting hideModernCommandBlockScreenFeatures = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.hide_modern_command_block_screen_features"), VersionRange.andOlder(ProtocolVersion.v1_8));
-    public final VersionedBooleanSetting enableSwordBlocking = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.enable_sword_blocking"), VersionRange.andOlder(ProtocolVersion.v1_8));
+    public final VersionedBooleanSetting swordBlockingAnimation = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.sword_blocking_animation"), VersionRange.andOlder(ProtocolVersion.v1_8));
 
     // 1.8.x -> 1.7.6 - 1.7.10
     public final VersionedBooleanSetting swingHandOnItemUse = new VersionedBooleanSetting(this, Text.translatable("visual_settings.viafabricplus.swing_hand_on_item_use"), VersionRange.andOlder(ProtocolVersion.v1_7_6));

--- a/src/main/resources/assets/viafabricplus/lang/de_de.json
+++ b/src/main/resources/assets/viafabricplus/lang/de_de.json
@@ -96,7 +96,7 @@
   "visual_settings.viafabricplus.replace_creative_inventory_with_classic_inventory": "Kreatives Inventar ersetzen",
   "visual_settings.viafabricplus.old_walking_animation": "Alte Laufanimation",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Schriftarten-Renderer-Verhalten ändern",
-  "visual_settings.viafabricplus.enable_sword_blocking": "Schwertanimation einschalten",
+  "visual_settings.viafabricplus.sword_blocking_animation": "Schwertanimation einschalten",
   "visual_settings.viafabricplus.swing_hand_on_item_use": "Hand schwingen, wenn Gegenstand benutzt wird",
   "visual_settings.viafabricplus.disable_server_pinging": "Server-Pinging deaktivieren",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Seitliches Rückwärtsgehen",

--- a/src/main/resources/assets/viafabricplus/lang/en_us.json
+++ b/src/main/resources/assets/viafabricplus/lang/en_us.json
@@ -96,7 +96,7 @@
   "visual_settings.viafabricplus.replace_creative_inventory_with_classic_inventory": "Replace creative inventory",
   "visual_settings.viafabricplus.old_walking_animation": "Old walking animation",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Change Font Renderer behavior",
-  "visual_settings.viafabricplus.enable_sword_blocking": "Enable sword animation",
+  "visual_settings.viafabricplus.sword_blocking_animation": "Enable sword blocking animation",
   "visual_settings.viafabricplus.swing_hand_on_item_use": "Swing hand on item use",
   "visual_settings.viafabricplus.disable_server_pinging": "Disable server pinging",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Sideways backwards walking",

--- a/src/main/resources/assets/viafabricplus/lang/es_ar.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_ar.json
@@ -77,7 +77,7 @@
   "visual_settings.viafabricplus.replace_creative_inventory_with_classic_inventory": "Reemplazar inventario del creativo",
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
-  "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
+  "visual_settings.viafabricplus.sword_blocking_animation": "habilitar animación de espada",
   "visual_settings.viafabricplus.swing_hand_on_item_use": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",

--- a/src/main/resources/assets/viafabricplus/lang/es_cl.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_cl.json
@@ -77,7 +77,7 @@
   "visual_settings.viafabricplus.replace_creative_inventory_with_classic_inventory": "Reemplazar inventario del creativo",
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
-  "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
+  "visual_settings.viafabricplus.sword_blocking_animation": "habilitar animación de espada",
   "visual_settings.viafabricplus.swing_hand_on_item_use": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",

--- a/src/main/resources/assets/viafabricplus/lang/es_ec.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_ec.json
@@ -77,7 +77,7 @@
   "visual_settings.viafabricplus.replace_creative_inventory_with_classic_inventory": "Reemplazar inventario del creativo",
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
-  "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
+  "visual_settings.viafabricplus.sword_blocking_animation": "habilitar animación de espada",
   "visual_settings.viafabricplus.swing_hand_on_item_use": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",

--- a/src/main/resources/assets/viafabricplus/lang/es_es.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_es.json
@@ -77,7 +77,7 @@
   "visual_settings.viafabricplus.replace_creative_inventory_with_classic_inventory": "Reemplazar inventario del creativo",
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
-  "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
+  "visual_settings.viafabricplus.sword_blocking_animation": "habilitar animación de espada",
   "visual_settings.viafabricplus.swing_hand_on_item_use": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",

--- a/src/main/resources/assets/viafabricplus/lang/es_mx.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_mx.json
@@ -77,7 +77,7 @@
   "visual_settings.viafabricplus.replace_creative_inventory_with_classic_inventory": "Reemplazar inventario del creativo",
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
-  "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
+  "visual_settings.viafabricplus.sword_blocking_animation": "habilitar animación de espada",
   "visual_settings.viafabricplus.swing_hand_on_item_use": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",

--- a/src/main/resources/assets/viafabricplus/lang/es_uy.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_uy.json
@@ -77,7 +77,7 @@
   "visual_settings.viafabricplus.replace_creative_inventory_with_classic_inventory": "Reemplazar inventario del creativo",
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
-  "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
+  "visual_settings.viafabricplus.sword_blocking_animation": "habilitar animación de espada",
   "visual_settings.viafabricplus.swing_hand_on_item_use": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",

--- a/src/main/resources/assets/viafabricplus/lang/es_ve.json
+++ b/src/main/resources/assets/viafabricplus/lang/es_ve.json
@@ -77,7 +77,7 @@
   "visual_settings.viafabricplus.replace_creative_inventory_with_classic_inventory": "Reemplazar inventario del creativo",
   "visual_settings.viafabricplus.old_walking_animation": "Animación de caminar antigua",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Cambiar el comportamiento del renderizador de fuentes",
-  "visual_settings.viafabricplus.enable_sword_blocking": "habilitar animación de espada",
+  "visual_settings.viafabricplus.sword_blocking_animation": "habilitar animación de espada",
   "visual_settings.viafabricplus.swing_hand_on_item_use": "Habilitar animación de golpe de bloque",
 
   "bedrock.viafabricplus.login": "Tu navegador debería haberse abierto.\nCerrar esta pantalla cancelará el proceso!",

--- a/src/main/resources/assets/viafabricplus/lang/hu_hu.json
+++ b/src/main/resources/assets/viafabricplus/lang/hu_hu.json
@@ -75,7 +75,7 @@
   "visual_settings.viafabricplus.replace_creative_inventory_with_classic_inventory": "Kreatív felszerelés kicserélése",
   "visual_settings.viafabricplus.old_walking_animation": "Régi séta animáció",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Betűkészlet renderelő viselkedésének módosítása",
-  "visual_settings.viafabricplus.enable_sword_blocking": "Kard animáció bekapcsolása",
+  "visual_settings.viafabricplus.sword_blocking_animation": "Kard animáció bekapcsolása",
   "visual_settings.viafabricplus.swing_hand_on_item_use": "Blokkolás-ütés animáció bekapcsolása",
 
   "bedrock.viafabricplus.login": "A böngésződnek meg kellett volna nyílnia.\nKérlek írd be a következő kódot: %s\nEzen képernyő bezárása megszakítja a folyamatot!",

--- a/src/main/resources/assets/viafabricplus/lang/ja_jp.json
+++ b/src/main/resources/assets/viafabricplus/lang/ja_jp.json
@@ -95,7 +95,7 @@
   "visual_settings.viafabricplus.replace_creative_inventory_with_classic_inventory": "クリエイティブインベントリを置換",
   "visual_settings.viafabricplus.old_walking_animation": "古いウォーキングアニメーション",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "フォントレンダラーの動作を変更",
-  "visual_settings.viafabricplus.enable_sword_blocking": "剣のブロックアニメーションを有効化",
+  "visual_settings.viafabricplus.sword_blocking_animation": "剣のブロックアニメーションを有効化",
   "visual_settings.viafabricplus.swing_hand_on_item_use": "アイテム使用時に手を振る",
   "visual_settings.viafabricplus.disable_server_pinging": "サーバーへのpingを無効化",
   "visual_settings.viafabricplus.sideways_backwards_walking": "横向き後方歩行",

--- a/src/main/resources/assets/viafabricplus/lang/ko_kr.json
+++ b/src/main/resources/assets/viafabricplus/lang/ko_kr.json
@@ -95,7 +95,7 @@
   "visual_settings.viafabricplus.replace_creative_inventory_with_classic_inventory": "크리에이티브 인벤토리를 클래식으로 바꾸기",
   "visual_settings.viafabricplus.old_walking_animation": "예전 걷기 에니메이션",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "폰트 렌더링 방식 바꾸기",
-  "visual_settings.viafabricplus.enable_sword_blocking": "칼로 막기 허용",
+  "visual_settings.viafabricplus.sword_blocking_animation": "칼로 막기 허용",
   "visual_settings.viafabricplus.swing_hand_on_item_use": "블럭 치는 에니메이션 허용",
   "visual_settings.viafabricplus.disable_server_pinging": "서버 핑 비활성화",
   "visual_settings.viafabricplus.sideways_backwards_walking": "옆과 뒤로 걷기",

--- a/src/main/resources/assets/viafabricplus/lang/lb_lu.json
+++ b/src/main/resources/assets/viafabricplus/lang/lb_lu.json
@@ -81,7 +81,7 @@
   "visual_settings.viafabricplus.replace_creative_inventory_with_classic_inventory": "Kreativ-Inventar ersätzen",
   "visual_settings.viafabricplus.old_walking_animation": "Aal Laafanimatioun",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Verhaalen vum Schreftarten-Renderer änneren",
-  "visual_settings.viafabricplus.enable_sword_blocking": "Schwertblockeierung aktivieieren",
+  "visual_settings.viafabricplus.sword_blocking_animation": "Schwertblockeierung aktivieieren",
   "visual_settings.viafabricplus.swing_hand_on_item_use": "Block-Trefferanimation aktiveieren",
   "visual_settings.viafabricplus.disable_server_pinging": "Server-Ping deaktiveieren",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Säitlicht hannerzech laafen",

--- a/src/main/resources/assets/viafabricplus/lang/lzh.json
+++ b/src/main/resources/assets/viafabricplus/lang/lzh.json
@@ -90,7 +90,7 @@
   "visual_settings.viafabricplus.replace_creative_inventory_with_classic_inventory": "替創之行囊",
   "visual_settings.viafabricplus.old_walking_animation": "舊行進之畫效",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "更字體理質器之爲",
-  "visual_settings.viafabricplus.enable_sword_blocking": "啟劍之畫效",
+  "visual_settings.viafabricplus.sword_blocking_animation": "啟劍之畫效",
   "visual_settings.viafabricplus.swing_hand_on_item_use": "於使物之時揮手",
   "visual_settings.viafabricplus.disable_server_pinging": "禁伺服器之測",
   "visual_settings.viafabricplus.sideways_backwards_walking": "側身卻行",

--- a/src/main/resources/assets/viafabricplus/lang/pl_pl.json
+++ b/src/main/resources/assets/viafabricplus/lang/pl_pl.json
@@ -96,7 +96,7 @@
   "visual_settings.viafabricplus.replace_creative_inventory_with_classic_inventory": "Zamień ekwipunek trybu kreatywnego",
   "visual_settings.viafabricplus.old_walking_animation": "Stara animacja chodzenia",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Zmień sposób renderowania czcionek",
-  "visual_settings.viafabricplus.enable_sword_blocking": "Włącz blokowanie mieczem",
+  "visual_settings.viafabricplus.sword_blocking_animation": "Włącz blokowanie mieczem",
   "visual_settings.viafabricplus.swing_hand_on_item_use": "Włącz animację niszczenia bloków 1.7",
   "visual_settings.viafabricplus.disable_server_pinging": "Wyłącz pingowanie serwerów",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Chodzenie do tyłu na boki",

--- a/src/main/resources/assets/viafabricplus/lang/ru_ru.json
+++ b/src/main/resources/assets/viafabricplus/lang/ru_ru.json
@@ -96,7 +96,7 @@
   "visual_settings.viafabricplus.replace_creative_inventory_with_classic_inventory": "Старый творческий инвентарь",
   "visual_settings.viafabricplus.old_walking_animation": "Старая анимация ходьбы",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Скрывать неизвестные Unicode-символы",
-  "visual_settings.viafabricplus.enable_sword_blocking": "Анимация меча",
+  "visual_settings.viafabricplus.sword_blocking_animation": "Анимация меча",
   "visual_settings.viafabricplus.swing_hand_on_item_use": "Объединить анимацию использования и удара",
   "visual_settings.viafabricplus.disable_server_pinging": "Не проверять соединение",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Старая походка спиной",

--- a/src/main/resources/assets/viafabricplus/lang/tr_tr.json
+++ b/src/main/resources/assets/viafabricplus/lang/tr_tr.json
@@ -89,7 +89,7 @@
   "visual_settings.viafabricplus.replace_creative_inventory_with_classic_inventory": "Creative Envanterini Değiştir",
   "visual_settings.viafabricplus.old_walking_animation": "Eski Yürüyüş Animasyonu",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Yazı Tipi Oluşturucu Davranışını Değiştirme",
-  "visual_settings.viafabricplus.enable_sword_blocking": "Kılıç Animasyonunu Aç",
+  "visual_settings.viafabricplus.sword_blocking_animation": "Kılıç Animasyonunu Aç",
   "visual_settings.viafabricplus.swing_hand_on_item_use": "Blok Hit Animasyonunu Aç",
   "visual_settings.viafabricplus.disable_server_pinging": "Veri Gönderimini Kapat",
   "visual_settings.viafabricplus.sideways_backwards_walking": "Yana Doğru Geri Geri Yürüme",

--- a/src/main/resources/assets/viafabricplus/lang/uk_ua.json
+++ b/src/main/resources/assets/viafabricplus/lang/uk_ua.json
@@ -75,7 +75,7 @@
   "visual_settings.viafabricplus.replace_creative_inventory_with_classic_inventory": "Замінити інвентар креативу",
   "visual_settings.viafabricplus.old_walking_animation": "Стара анімація ходьби",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "Змінити поведінку рендерингу шрифта",
-  "visual_settings.viafabricplus.enable_sword_blocking": "Увімкнути блокування мечем",
+  "visual_settings.viafabricplus.sword_blocking_animation": "Увімкнути блокування мечем",
   "visual_settings.viafabricplus.swing_hand_on_item_use": "Ввімкнути анімацію удару блоку 1.7",
 
   "bedrock.viafabricplus.login": "Ваш браузер мав відкритися.\nБудь ласка, введіть наступний код: %s\nЯкщо закрити цей екран, процес буде скасовано!",

--- a/src/main/resources/assets/viafabricplus/lang/zh_cn.json
+++ b/src/main/resources/assets/viafabricplus/lang/zh_cn.json
@@ -96,7 +96,7 @@
   "visual_settings.viafabricplus.replace_creative_inventory_with_classic_inventory": "替换创造模式物品栏",
   "visual_settings.viafabricplus.old_walking_animation": "旧版行走动画",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "更改字体渲染器行为",
-  "visual_settings.viafabricplus.enable_sword_blocking": "启用剑动画",
+  "visual_settings.viafabricplus.sword_blocking_animation": "启用剑动画",
   "visual_settings.viafabricplus.swing_hand_on_item_use": "使用物品时挥动手",
   "visual_settings.viafabricplus.disable_server_pinging": "禁用服务器Ping",
   "visual_settings.viafabricplus.sideways_backwards_walking": "侧身后退行走",

--- a/src/main/resources/assets/viafabricplus/lang/zh_hk.json
+++ b/src/main/resources/assets/viafabricplus/lang/zh_hk.json
@@ -89,7 +89,7 @@
   "visual_settings.viafabricplus.replace_creative_inventory_with_classic_inventory": "將創造模式物品欄替換為舊版本樣式",
   "visual_settings.viafabricplus.old_walking_animation": "舊版行走動畫",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "改變字體渲染嘅行為",
-  "visual_settings.viafabricplus.enable_sword_blocking": "啟用 1.8 劍阻擋動畫",
+  "visual_settings.viafabricplus.sword_blocking_animation": "啟用 1.8 劍阻擋動畫",
   "visual_settings.viafabricplus.swing_hand_on_item_use": "啟用 1.7 阻擋攻擊動畫",
   "visual_settings.viafabricplus.disable_server_pinging": "禁用伺服器 pinging",
   "visual_settings.viafabricplus.sideways_backwards_walking": "側身倒退行走",

--- a/src/main/resources/assets/viafabricplus/lang/zh_tw.json
+++ b/src/main/resources/assets/viafabricplus/lang/zh_tw.json
@@ -95,7 +95,7 @@
   "visual_settings.viafabricplus.replace_creative_inventory_with_classic_inventory": "取代創造模式物品欄",
   "visual_settings.viafabricplus.old_walking_animation": "舊版行走動畫",
   "visual_settings.viafabricplus.change_font_renderer_behaviour": "變更字型渲染器行為",
-  "visual_settings.viafabricplus.enable_sword_blocking": "啟用 1.8 劍格擋動畫",
+  "visual_settings.viafabricplus.sword_blocking_animation": "啟用 1.8 劍格擋動畫",
   "visual_settings.viafabricplus.swing_hand_on_item_use": "使用物品時揮動慣用手",
   "visual_settings.viafabricplus.disable_server_pinging": "停用伺服器 Ping",
   "visual_settings.viafabricplus.sideways_backwards_walking": "側身倒退行走",


### PR DESCRIPTION
Renames "enableSwordAnimation" to "swordBlockingAnimation" to matching naming scheme/usage & adds check to not apply rotations if item is of shield, to fix issue in 1.9+ when the setting is enabled. 1.21.4 does this.