### PR TITLE
Added support for some movement differences on Bedrock <-> Java (Draft)

### DIFF
--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/entity/MixinLivingEntity.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/entity/MixinLivingEntity.java
@@ -46,6 +46,7 @@ import net.raphimc.viabedrock.api.BedrockProtocolVersion;
 import net.raphimc.vialegacy.api.LegacyProtocolVersion;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -80,16 +81,20 @@ public abstract class MixinLivingEntity extends Entity {
 
     @Shadow public float forwardSpeed;
 
+    @Unique
+    private float viaFabricPlus$bedrockInputMultiplier = 0.70710677F;
+
     public MixinLivingEntity(EntityType<?> type, World world) {
         super(type, world);
     }
 
     @Inject(method = "tickMovement", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiler/Profiler;push(Ljava/lang/String;)V", ordinal = 3, shift = At.Shift.AFTER))
     private void bedrockXZInput(CallbackInfo ci) {
-        if (this.sidewaysSpeed != 0 && this.forwardSpeed != 0) {
-            float value = (float) (1F / Math.sqrt(2));
-            this.sidewaysSpeed *= value;
-            this.forwardSpeed *= value;
+        if (ProtocolTranslator.getTargetVersion().equals(BedrockProtocolVersion.bedrockLatest)) {
+            if (this.sidewaysSpeed != 0 && this.forwardSpeed != 0) {
+                this.sidewaysSpeed *= viaFabricPlus$bedrockInputMultiplier;
+                this.forwardSpeed *= viaFabricPlus$bedrockInputMultiplier;
+            }
         }
     }
 
@@ -258,7 +263,7 @@ public abstract class MixinLivingEntity extends Entity {
     private double modifyVelocityZero(final double constant) {
         if (ProtocolTranslator.getTargetVersion().equals(BedrockProtocolVersion.bedrockLatest)) {
             return 0D;
-        }else if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_8)) {
+        } else if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_8)) {
             return 0.005D;
         } else {
             return constant;

--- a/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/entity/MixinLivingEntity.java
+++ b/src/main/java/de/florianmichael/viafabricplus/injection/mixin/fixes/minecraft/entity/MixinLivingEntity.java
@@ -87,8 +87,9 @@ public abstract class MixinLivingEntity extends Entity {
     @Inject(method = "tickMovement", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiler/Profiler;push(Ljava/lang/String;)V", ordinal = 3, shift = At.Shift.AFTER))
     private void bedrockXZInput(CallbackInfo ci) {
         if (this.sidewaysSpeed != 0 && this.forwardSpeed != 0) {
-            this.sidewaysSpeed *= (float) (1F / Math.sqrt(2));
-            this.forwardSpeed *= (float) (1F / Math.sqrt(2));
+            float value = (float) (1F / Math.sqrt(2));
+            this.sidewaysSpeed *= value;
+            this.forwardSpeed *= value;
         }
     }
 


### PR DESCRIPTION
- Bedrock doesn't seems to have modifyVelocityZero (0.003/0.005D), the movement appear to just slowly going down until it reaches 0 (or some extremely small value).
- If you moving on both X and Z axis your movement input get multiplied by 1f / Math.sqrt(2), you can get this value by debugging using ProxyPass and check for input value bedrock send.

Also this is tested on [here](https://github.com/Oryxel/Boar), an anti-cheat that I'm currently working on that is incomplete but is good enough to check for (1e-4) movement differences if you just walking around normally.