### PR TITLE
Update JitPack, Loom 1.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id "idea"
 	id "maven-publish"
-	id "fabric-loom" version "1.8-SNAPSHOT"
+	id "fabric-loom" version "1.9-SNAPSHOT"
 }
 
 base {

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,7 +1,7 @@
-# Deploys the latest stable JDK 21 available and sets it to default without having to manually specify it here,
+# Deploys the specified JDK version and sets it to default,
 # Which includes using temurin as the distribution.
 before_install:
   - curl -s "https://get.sdkman.io" | bash
   - source ~/.sdkman/bin/sdkman-init.sh
-  - sdk install java 21.0.3-tem
-  - sdk use java 21.0.3-tem
+  - sdk install java 21.0.5-tem
+  - sdk use java 21.0.5-tem


### PR DESCRIPTION
1. Update JDK to 21.0.5 in JitPack,
2. Updates Fabric Loom to 1.9+ to address Gradle-related issues in terms of building.