### PR TITLE
Fix <= 1.8.x pane collision shapes; Fix <= 1.12.2 legacy pane outline shapes

### DIFF
--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/block/shape/MixinPaneBlock.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/block/shape/MixinPaneBlock.java
@@ -63,14 +63,14 @@ public abstract class MixinPaneBlock extends HorizontalConnectingBlock implement
 
         viaFabricPlus$shape_r1_8 = new VoxelShape[]{
                 VoxelShapes.empty(),
-                Block.createCuboidShape(h, (float) 0.0, h, i, (float) 16.0, 16.0D), // south
-                Block.createCuboidShape(0.0D, (float) 0.0, h, i, (float) 16.0, i), // west
+                Block.createCuboidShape(h, (float) 0.0, h + 1, i, (float) 16.0, 16.0D), // south
+                Block.createCuboidShape(0.0D, (float) 0.0, h, i - 1, (float) 16.0, i), // west
                 southWestCornerShape,
-                Block.createCuboidShape(h, (float) 0.0, 0.0D, i, (float) 16.0, i), // north
+                Block.createCuboidShape(h, (float) 0.0, 0.0D, i, (float) 16.0, i - 1), // north
                 VoxelShapes.union(southShape, northShape),
                 VoxelShapes.union(westShape, northShape),
                 VoxelShapes.union(southWestCornerShape, northShape),
-                Block.createCuboidShape(h, (float) 0.0, h, 16.0D, (float) 16.0, i), // east
+                Block.createCuboidShape(h + 1, (float) 0.0, h, 16.0D, (float) 16.0, i), // east
                 VoxelShapes.union(southShape, eastShape),
                 VoxelShapes.union(westShape, eastShape),
                 VoxelShapes.union(southWestCornerShape, eastShape),

--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/block/shape/MixinPaneBlock.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/block/shape/MixinPaneBlock.java
@@ -87,15 +87,6 @@ public abstract class MixinPaneBlock extends HorizontalConnectingBlock implement
     }
 
     @Override
-    public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
-        if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_8)) {
-            return this.viaFabricPlus$shape_r1_8[this.viaFabricPlus$getShapeIndex(state)];
-        } else {
-            return super.getOutlineShape(state, world, pos, context);
-        }
-    }
-
-    @Override
     public VoxelShape getCollisionShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
         if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_8)) {
             return this.viaFabricPlus$shape_r1_8[this.viaFabricPlus$getShapeIndex(state)];

--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/block/shape/MixinPaneBlock.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/block/shape/MixinPaneBlock.java
@@ -63,14 +63,14 @@ public abstract class MixinPaneBlock extends HorizontalConnectingBlock implement
 
         viaFabricPlus$shape_r1_8 = new VoxelShape[]{
                 VoxelShapes.empty(),
-                Block.createCuboidShape(h, (float) 0.0, h + 1, i, (float) 16.0, 16.0D), // south
-                Block.createCuboidShape(0.0D, (float) 0.0, h, i - 1, (float) 16.0, i), // west
+                Block.createCuboidShape(h, (float) 0.0, h, i, (float) 16.0, 16.0D), // south
+                Block.createCuboidShape(0.0D, (float) 0.0, h, i, (float) 16.0, i), // west
                 southWestCornerShape,
-                Block.createCuboidShape(h, (float) 0.0, 0.0D, i, (float) 16.0, i - 1), // north
+                Block.createCuboidShape(h, (float) 0.0, 0.0D, i, (float) 16.0, i), // north
                 VoxelShapes.union(southShape, northShape),
                 VoxelShapes.union(westShape, northShape),
                 VoxelShapes.union(southWestCornerShape, northShape),
-                Block.createCuboidShape(h + 1, (float) 0.0, h, 16.0D, (float) 16.0, i), // east
+                Block.createCuboidShape(h, (float) 0.0, h, 16.0D, (float) 16.0, i), // east
                 VoxelShapes.union(southShape, eastShape),
                 VoxelShapes.union(westShape, eastShape),
                 VoxelShapes.union(southWestCornerShape, eastShape),

--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/block/shape/MixinPaneBlock.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/block/shape/MixinPaneBlock.java
@@ -23,6 +23,7 @@ package com.viaversion.viafabricplus.injection.mixin.features.block.shape;
 
 import com.viaversion.viafabricplus.injection.access.block.shape.IHorizontalConnectingBlock;
 import com.viaversion.viafabricplus.protocoltranslator.ProtocolTranslator;
+import com.viaversion.viafabricplus.settings.impl.DebugSettings;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import net.minecraft.block.*;
 import net.minecraft.util.math.BlockPos;
@@ -40,6 +41,9 @@ public abstract class MixinPaneBlock extends HorizontalConnectingBlock implement
 
     @Unique
     private VoxelShape[] viaFabricPlus$shape_r1_8;
+
+    @Unique
+    private VoxelShape[] viaFabricPlus$shape_r1_12;
 
     protected MixinPaneBlock(float radius1, float radius2, float boundingHeight1, float boundingHeight2, float collisionHeight, Settings settings) {
         super(radius1, radius2, boundingHeight1, boundingHeight2, collisionHeight, settings);
@@ -80,6 +84,33 @@ public abstract class MixinPaneBlock extends HorizontalConnectingBlock implement
                 VoxelShapes.union(southWestCornerShape, northEastCornerShape)
         };
 
+        viaFabricPlus$shape_r1_12 = new VoxelShape[]{
+                baseShape,
+                Block.createCuboidShape(h, 0.0, h, i, 16.0, 16.0), // south
+                Block.createCuboidShape(0.0, 0.0, h, i, 16.0, i), // west
+                Block.createCuboidShape(0.0, 0.0, h, i, 16.0, 16.0), // south-west corner
+                Block.createCuboidShape(h, 0.0, 0.0, i, 16.0, i), // north
+                Block.createCuboidShape(h, 0.0, 0.0, i, 16.0, 16.0), // south-north line
+                Block.createCuboidShape(0.0, 0.0, 0.0, i, 16.0, i), // west-north corner
+                Block.createCuboidShape(0.0, 0.0, 0.0, i, 16.0, 16.0), // south-west-north T
+                Block.createCuboidShape(h, 0.0, h, 16.0, 16.0, i), // east
+                Block.createCuboidShape(h, 0.0, h, 16.0, 16.0, 16.0), // south-east corner
+                Block.createCuboidShape(0.0, 0.0, h, 16.0, 16.0, i), // west-east line
+                Block.createCuboidShape(0.0, 0.0, h, 16.0, 16.0, 16.0), // south-west-east T
+                Block.createCuboidShape(h, 0.0, 0.0, 16.0, 16.0, i), // north-east corner
+                Block.createCuboidShape(h, 0.0, 0.0, 16.0, 16.0, 16.0), // south-north-east T
+                Block.createCuboidShape(0.0, 0.0, 0.0, 16.0, 16.0, i), // west-north-east T
+                VoxelShapes.fullCube() // cross
+        };
+    }
+
+    @Override
+    public VoxelShape getOutlineShape(final BlockState state, final BlockView world, final BlockPos pos, final ShapeContext context) {
+        if (DebugSettings.INSTANCE.legacyPaneOutlines.isEnabled()) {
+            return this.viaFabricPlus$shape_r1_12[this.viaFabricPlus$getShapeIndex(state)];
+        } else {
+            return super.getOutlineShape(state, world, pos, context);
+        }
     }
 
     @Override

--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/block/shape/MixinPaneBlock.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/block/shape/MixinPaneBlock.java
@@ -105,7 +105,7 @@ public abstract class MixinPaneBlock extends HorizontalConnectingBlock implement
     }
 
     @Override
-    public VoxelShape getOutlineShape(final BlockState state, final BlockView world, final BlockPos pos, final ShapeContext context) {
+    public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
         if (DebugSettings.INSTANCE.legacyPaneOutlines.isEnabled()) {
             return this.viaFabricPlus$shape_r1_12[this.viaFabricPlus$getShapeIndex(state)];
         } else {

--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/block/shape/MixinPaneBlock.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/block/shape/MixinPaneBlock.java
@@ -40,10 +40,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class MixinPaneBlock extends HorizontalConnectingBlock implements IHorizontalConnectingBlock {
 
     @Unique
-    private VoxelShape[] viaFabricPlus$shape_r1_8;
+    private VoxelShape[] viaFabricPlus$shape_r1_12;
 
     @Unique
-    private VoxelShape[] viaFabricPlus$shape_r1_12;
+    private VoxelShape[] viaFabricPlus$shape_r1_8;
 
     protected MixinPaneBlock(float radius1, float radius2, float boundingHeight1, float boundingHeight2, float collisionHeight, Settings settings) {
         super(radius1, radius2, boundingHeight1, boundingHeight2, collisionHeight, settings);
@@ -57,6 +57,26 @@ public abstract class MixinPaneBlock extends HorizontalConnectingBlock implement
         final float i = 9.0F;
 
         final VoxelShape baseShape = Block.createCuboidShape(f, 0.0, f, g, (float) 16.0, g);
+
+        viaFabricPlus$shape_r1_12 = new VoxelShape[]{
+            baseShape,
+            Block.createCuboidShape(h, 0.0, h, i, 16.0, 16.0), // south
+            Block.createCuboidShape(0.0, 0.0, h, i, 16.0, i), // west
+            Block.createCuboidShape(0.0, 0.0, h, i, 16.0, 16.0), // south-west corner
+            Block.createCuboidShape(h, 0.0, 0.0, i, 16.0, i), // north
+            Block.createCuboidShape(h, 0.0, 0.0, i, 16.0, 16.0), // south-north line
+            Block.createCuboidShape(0.0, 0.0, 0.0, i, 16.0, i), // west-north corner
+            Block.createCuboidShape(0.0, 0.0, 0.0, i, 16.0, 16.0), // south-west-north T
+            Block.createCuboidShape(h, 0.0, h, 16.0, 16.0, i), // east
+            Block.createCuboidShape(h, 0.0, h, 16.0, 16.0, 16.0), // south-east corner
+            Block.createCuboidShape(0.0, 0.0, h, 16.0, 16.0, i), // west-east line
+            Block.createCuboidShape(0.0, 0.0, h, 16.0, 16.0, 16.0), // south-west-east T
+            Block.createCuboidShape(h, 0.0, 0.0, 16.0, 16.0, i), // north-east corner
+            Block.createCuboidShape(h, 0.0, 0.0, 16.0, 16.0, 16.0), // south-north-east T
+            Block.createCuboidShape(0.0, 0.0, 0.0, 16.0, 16.0, i), // west-north-east T
+            VoxelShapes.fullCube() // cross
+        };
+
         final VoxelShape northShape = Block.createCuboidShape(h, (float) 0.0, 0.0, i, (float) 16.0, i - 1);
         final VoxelShape southShape = Block.createCuboidShape(h, (float) 0.0, h + 1, i, (float) 16.0, 16.0);
         final VoxelShape westShape = Block.createCuboidShape(0.0, (float) 0.0, h, i - 1, (float) 16.0, i);
@@ -82,25 +102,6 @@ public abstract class MixinPaneBlock extends HorizontalConnectingBlock implement
                 VoxelShapes.union(southShape, northEastCornerShape),
                 VoxelShapes.union(westShape, northEastCornerShape),
                 VoxelShapes.union(southWestCornerShape, northEastCornerShape)
-        };
-
-        viaFabricPlus$shape_r1_12 = new VoxelShape[]{
-                baseShape,
-                Block.createCuboidShape(h, 0.0, h, i, 16.0, 16.0), // south
-                Block.createCuboidShape(0.0, 0.0, h, i, 16.0, i), // west
-                Block.createCuboidShape(0.0, 0.0, h, i, 16.0, 16.0), // south-west corner
-                Block.createCuboidShape(h, 0.0, 0.0, i, 16.0, i), // north
-                Block.createCuboidShape(h, 0.0, 0.0, i, 16.0, 16.0), // south-north line
-                Block.createCuboidShape(0.0, 0.0, 0.0, i, 16.0, i), // west-north corner
-                Block.createCuboidShape(0.0, 0.0, 0.0, i, 16.0, 16.0), // south-west-north T
-                Block.createCuboidShape(h, 0.0, h, 16.0, 16.0, i), // east
-                Block.createCuboidShape(h, 0.0, h, 16.0, 16.0, 16.0), // south-east corner
-                Block.createCuboidShape(0.0, 0.0, h, 16.0, 16.0, i), // west-east line
-                Block.createCuboidShape(0.0, 0.0, h, 16.0, 16.0, 16.0), // south-west-east T
-                Block.createCuboidShape(h, 0.0, 0.0, 16.0, 16.0, i), // north-east corner
-                Block.createCuboidShape(h, 0.0, 0.0, 16.0, 16.0, 16.0), // south-north-east T
-                Block.createCuboidShape(0.0, 0.0, 0.0, 16.0, 16.0, i), // west-north-east T
-                VoxelShapes.fullCube() // cross
         };
     }
 

--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/block/shape/MixinPaneBlock.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/block/shape/MixinPaneBlock.java
@@ -53,24 +53,24 @@ public abstract class MixinPaneBlock extends HorizontalConnectingBlock implement
         final float i = 9.0F;
 
         final VoxelShape baseShape = Block.createCuboidShape(f, 0.0, f, g, (float) 16.0, g);
-        final VoxelShape northShape = Block.createCuboidShape(h, (float) 0.0, 0.0, i, (float) 16.0, i);
-        final VoxelShape southShape = Block.createCuboidShape(h, (float) 0.0, h, i, (float) 16.0, 16.0);
-        final VoxelShape westShape = Block.createCuboidShape(0.0, (float) 0.0, h, i, (float) 16.0, i);
-        final VoxelShape eastShape = Block.createCuboidShape(h, (float) 0.0, h, 16.0, (float) 16.0, i);
+        final VoxelShape northShape = Block.createCuboidShape(h, (float) 0.0, 0.0, i, (float) 16.0, i - 1);
+        final VoxelShape southShape = Block.createCuboidShape(h, (float) 0.0, h + 1, i, (float) 16.0, 16.0);
+        final VoxelShape westShape = Block.createCuboidShape(0.0, (float) 0.0, h, i - 1, (float) 16.0, i);
+        final VoxelShape eastShape = Block.createCuboidShape(h + 1, (float) 0.0, h, 16.0, (float) 16.0, i);
 
         final VoxelShape northEastCornerShape = VoxelShapes.union(northShape, eastShape);
         final VoxelShape southWestCornerShape = VoxelShapes.union(southShape, westShape);
 
         viaFabricPlus$shape_r1_8 = new VoxelShape[]{
-                VoxelShapes.empty(),
-                Block.createCuboidShape(h, (float) 0.0, h + 1, i, (float) 16.0, 16.0D), // south
-                Block.createCuboidShape(0.0D, (float) 0.0, h, i - 1, (float) 16.0, i), // west
+                baseShape,
+                southShape,
+                westShape,
                 southWestCornerShape,
-                Block.createCuboidShape(h, (float) 0.0, 0.0D, i, (float) 16.0, i - 1), // north
+                northShape,
                 VoxelShapes.union(southShape, northShape),
                 VoxelShapes.union(westShape, northShape),
                 VoxelShapes.union(southWestCornerShape, northShape),
-                Block.createCuboidShape(h + 1, (float) 0.0, h, 16.0D, (float) 16.0, i), // east
+                eastShape,
                 VoxelShapes.union(southShape, eastShape),
                 VoxelShapes.union(westShape, eastShape),
                 VoxelShapes.union(southWestCornerShape, eastShape),
@@ -80,10 +80,6 @@ public abstract class MixinPaneBlock extends HorizontalConnectingBlock implement
                 VoxelShapes.union(southWestCornerShape, northEastCornerShape)
         };
 
-        for (int j = 0; j < 16; ++j) {
-            if (j == 1 || j == 2 || j == 4 || j == 8) continue;
-            viaFabricPlus$shape_r1_8[j] = VoxelShapes.union(baseShape, viaFabricPlus$shape_r1_8[j]);
-        }
     }
 
     @Override

--- a/src/main/java/com/viaversion/viafabricplus/settings/impl/DebugSettings.java
+++ b/src/main/java/com/viaversion/viafabricplus/settings/impl/DebugSettings.java
@@ -57,6 +57,7 @@ public final class DebugSettings extends SettingGroup {
     // 1.13 -> 1.12.2
     public final VersionedBooleanSetting executeInputsSynchronously = new VersionedBooleanSetting(this, Text.translatable("debug_settings.viafabricplus.execute_inputs_synchronously"), VersionRange.andOlder(ProtocolVersion.v1_12_2));
     public final VersionedBooleanSetting legacyTabCompletions = new VersionedBooleanSetting(this, Text.translatable("debug_settings.viafabricplus.legacy_tab_completions"), VersionRange.andOlder(ProtocolVersion.v1_12_2));
+    public final VersionedBooleanSetting legacyPaneOutlines = new VersionedBooleanSetting(this, Text.translatable("debug_settings.viafabricplus.legacy_pane_outlines"), VersionRange.andOlder(ProtocolVersion.v1_12_2));
 
     // 1.9 -> 1.8.x
     public final VersionedBooleanSetting emulateArmorHud = new VersionedBooleanSetting(this, Text.translatable("debug_settings.viafabricplus.emulate_armor_hud"), VersionRange.andOlder(ProtocolVersion.v1_8));

--- a/src/main/resources/assets/viafabricplus/lang/en_us.json
+++ b/src/main/resources/assets/viafabricplus/lang/en_us.json
@@ -78,6 +78,7 @@
   "debug_settings.viafabricplus.hide_modern_command_block_screen_features": "Hide modern command block screen features",
   "debug_settings.viafabricplus.disable_server_pinging": "Disable server pinging",
   "debug_settings.viafabricplus.filter_non_existing_glyphs": "Filter non existing glyphs",
+  "debug_settings.viafabricplus.legacy_pane_outlines": "Legacy pane outlines",
 
   "authentication_settings.viafabricplus.use_beta_craft_authentication": "Use BetaCraft authentication",
   "authentication_settings.viafabricplus.verify_session_for_online_mode": "Verify session for online mode servers",

--- a/src/main/resources/assets/viafabricplus/lang/fr_fr.json
+++ b/src/main/resources/assets/viafabricplus/lang/fr_fr.json
@@ -29,6 +29,7 @@
   "debug_settings.viafabricplus.replace_sneaking": "Remplacer le sneaking",
   "debug_settings.viafabricplus.long_sneaking": "Sneaking prolongé",
   "debug_settings.viafabricplus.legacy_mining_speeds": "Vitesses d'exploitation minière héritées",
+  "debug_settings.viafabricplus.legacy_pane_outlines": "Silhouettes de vitres et barreaux héritées",
 
   "authentication_settings.viafabricplus.use_beta_craft_authentication": "Utiliser l'authentification BetaCraft",
   "authentication_settings.viafabricplus.verify_session_for_online_mode": "Autoriser ViaLegacy à appeler joinServer() pour vérifier la session",


### PR DESCRIPTION
## <= 1.8.x pane shapes

- Fixed collision shapes in corner cases, using `VoxelShapes#union` with the base shape removed the pixel where you could get stuck
- Fixed outline shapes:

Before:
![2025-05-23_22 28 07](https://github.com/user-attachments/assets/ee646267-a658-4282-8c65-3ea8c0d03e9c)

After:
![2025-05-23_22 32 23](https://github.com/user-attachments/assets/7793dc63-f8bf-4128-83e3-d9c0d4f63e98)

## <= 1.12.2 outline shapes

- Ported the blocky pane shapes that are present in <= 1.12.2