### PR TITLE
Uncap player pitch movement in <=1.21.4

### DIFF
--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/movement/jump/MixinLivingEntity.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/movement/jump/MixinLivingEntity.java
@@ -21,8 +21,6 @@
 
 package com.viaversion.viafabricplus.injection.mixin.features.movement.jump;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.viaversion.viafabricplus.protocoltranslator.ProtocolTranslator;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import net.minecraft.entity.LivingEntity;
@@ -52,16 +50,6 @@ public abstract class MixinLivingEntity {
     private void removeJumpDelay(CallbackInfo ci) {
         if (ProtocolTranslator.getTargetVersion().olderThan(LegacyProtocolVersion.r1_0_0tor1_0_1)) {
             this.jumpingCooldown = 0;
-        }
-    }
-
-    @WrapOperation(method = "jump", at = @At(value = "INVOKE", target = "Ljava/lang/Math;max(DD)D"))
-    private double fixJumpVelocity(double value, double max, Operation<Double> original) {
-        // https://minecraft.wiki/w/Slime_Block#cite_note-6
-        if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_21)) {
-            return value;
-        } else {
-            return original.call(value, max);
         }
     }
 

--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/movement/jump/MixinLivingEntity.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/movement/jump/MixinLivingEntity.java
@@ -21,6 +21,8 @@
 
 package com.viaversion.viafabricplus.injection.mixin.features.movement.jump;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.viaversion.viafabricplus.protocoltranslator.ProtocolTranslator;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import net.minecraft.entity.LivingEntity;
@@ -50,6 +52,16 @@ public abstract class MixinLivingEntity {
     private void removeJumpDelay(CallbackInfo ci) {
         if (ProtocolTranslator.getTargetVersion().olderThan(LegacyProtocolVersion.r1_0_0tor1_0_1)) {
             this.jumpingCooldown = 0;
+        }
+    }
+
+    @WrapOperation(method = "jump", at = @At(value = "INVOKE", target = "Ljava/lang/Math;max(DD)D"))
+    private double fixJumpVelocity(double value, double max, Operation<Double> original) {
+        // https://minecraft.wiki/w/Slime_Block#cite_note-6
+        if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_21)) {
+            return value;
+        } else {
+            return original.call(value, max);
         }
     }
 

--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/movement/packet/MixinPlayerPosition.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/movement/packet/MixinPlayerPosition.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of ViaFabricPlus - https://github.com/ViaVersion/ViaFabricPlus
+ * Copyright (C) 2021-2025 the original authors
+ *                         - FlorianMichael/EnZaXD <florian.michael07@gmail.com>
+ *                         - RK_01/RaphiMC
+ * Copyright (C) 2023-2025 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.viaversion.viafabricplus.injection.mixin.features.movement.packet;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.viaversion.viafabricplus.protocoltranslator.ProtocolTranslator;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import net.minecraft.entity.player.PlayerPosition;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(PlayerPosition.class)
+public abstract class MixinPlayerPosition {
+
+    @WrapOperation(method = "apply", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/MathHelper;clamp(FFF)F"))
+    private static float uncapPlayerPitchMovement(float value, float min, float max, Operation<Float> original) {
+        if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_21_4)) {
+            return value;
+        } else {
+            return original.call(value, min, max);
+        }
+    }
+
+}

--- a/src/main/resources/viafabricplus.mixins.json
+++ b/src/main/resources/viafabricplus.mixins.json
@@ -210,6 +210,7 @@
     "features.movement.limitation.rotation.MixinEntity",
     "features.movement.limitation.rotation.MixinPlayerEntity",
     "features.movement.packet.MixinClientPlayerEntity",
+    "features.movement.packet.MixinPlayerPosition",
     "features.movement.slowdown.MixinClientPlayerEntity",
     "features.movement.slowdown.MixinEnderEyeItem",
     "features.movement.sprinting_and_sneaking.MixinClientPlayerEntity",


### PR DESCRIPTION
Removes the -90/90 cap of the pitch movement in PlayerRotation for <=1.21.4

Related:
https://github.com/ViaVersion/ViaFabricPlus/issues/742