### PR TITLE
Fix epsilon in block intersection for <=1.21.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # 6.0.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # 6.0.1
         with:
           persist-credentials: false
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # 5.0.0
       - name: Set up JDK 21
-        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # 5.0.0
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # 5.1.0
         with:
           distribution: 'temurin'
           java-version: 21

--- a/.github/workflows/sync-crowdin.yml
+++ b/.github/workflows/sync-crowdin.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # 6.0.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # 6.0.1
         with:
           persist-credentials: false
       - name: Crowdin Sync
-        uses: crowdin/github-action@08713f00a50548bfe39b37e8f44afb53e7a802d4 # 2.12.0
+        uses: crowdin/github-action@60debf382ee245b21794321190ad0501db89d8c1 # 2.13.0
         with:
           config: .github/crowdin.yml
           upload_sources: true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ pluginManagement {
 
     plugins {
         id("net.fabricmc.fabric-loom-remap") version "1.14-SNAPSHOT"
-        id("de.florianmichael.baseproject.BaseProject") version "1.3.1"
+        id("de.florianmichael.baseproject.BaseProject") version "1.3.2"
     }
 }
 


### PR DESCRIPTION
Fixes epsilon value in MixinBlockGetter#forEachBlockIntersectedBetween in <=1.21.8 as it changed in 1.21.9 and is causing issues for older protocols.

Notablely fixing the soulsand movement issue in <=1.8.x (Fixes #966)