### PR TITLE
Fix usage mining in <=1.7.x where mining progress wasn't resetting...

### DIFF
--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/interaction/replace_block_item_use_logic/MixinMultiPlayerGameMode.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/interaction/replace_block_item_use_logic/MixinMultiPlayerGameMode.java
@@ -252,7 +252,7 @@ public abstract class MixinMultiPlayerGameMode {
 
     @WrapWithCondition(method = "stopDestroyBlock", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/multiplayer/ClientPacketListener;send(Lnet/minecraft/network/protocol/Packet;)V"))
     private boolean preventPacketWhenNotMining1_7(ClientPacketListener instance, Packet<?> packet) {
-        return !ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_7_6) || this.isDestroying;
+        return ProtocolTranslator.getTargetVersion().newerThan(ProtocolVersion.v1_7_6) || this.isDestroying;
     }
 
     @Unique


### PR DESCRIPTION
In <=1.7.x, you were able to mine blocks while using a item, which worked fine.

They removed that in 1.8 and changed the code in "stopDestroyingBlock", so when you re-add the real functionality, your mining progress wouldn't reset properly anymore due to this change. This PR reverts those changes in 1.8 and makes it work properly in <=1.7.x now.