### PR TITLE
Fix "Open To Lan" Button Position for Authentic Screen Setting

### DIFF
--- a/viafabricplus-visuals/src/main/java/com/viaversion/viafabricplus/visuals/injection/mixin/remove_newer_screen_features/MixinPauseScreen.java
+++ b/viafabricplus-visuals/src/main/java/com/viaversion/viafabricplus/visuals/injection/mixin/remove_newer_screen_features/MixinPauseScreen.java
@@ -79,6 +79,9 @@ public abstract class MixinPauseScreen extends Screen {
     @Unique
     private Button.OnPress viaFabricPlusVisuals$disconnectSupplier;
 
+    @Unique
+    private Button viaFabricPlusVisuals$openToLanButton;
+
     protected MixinPauseScreen(Component title) {
         super(title);
     }
@@ -91,9 +94,9 @@ public abstract class MixinPauseScreen extends Screen {
         if (VisualSettings.INSTANCE.changeGameMenuScreenLayout.getIndex() == 0) {
             // Player reporting -> share to lan
             if (ViaFabricPlus.getImpl().getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_19) && text.equals(PLAYER_REPORTING)) {
-                final Button button = Button.builder(SHARE_TO_LAN, buttonWidget -> new ShareToLanScreen(instance)).width(BUTTON_WIDTH_HALF).build();
-                button.active = false;
-                return button;
+                viaFabricPlusVisuals$openToLanButton = Button.builder(SHARE_TO_LAN, buttonWidget -> new ShareToLanScreen(instance)).width(BUTTON_WIDTH_HALF).build();
+                viaFabricPlusVisuals$openToLanButton.active = false;
+                return viaFabricPlusVisuals$openToLanButton;
             }
             // Advancements -> disconnect
             if (ViaFabricPlus.getImpl().getTargetVersion().olderThanOrEqualTo(LegacyProtocolVersion.b1_4tob1_4_1) && text.equals(ADVANCEMENTS)) {
@@ -124,7 +127,7 @@ public abstract class MixinPauseScreen extends Screen {
         // Move all buttons below feebdack/bug down since they are removed
         if (ViaFabricPlus.getImpl().getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_13_2)) {
             viaFabricPlusVisuals$applyTo(OPTIONS, moveDown);
-            viaFabricPlusVisuals$applyTo(SHARE_TO_LAN, moveDown);
+            moveDown.accept(viaFabricPlusVisuals$openToLanButton);
             viaFabricPlusVisuals$applyTo(CommonComponents.GUI_DISCONNECT, moveDown);
         }
 


### PR DESCRIPTION
Before:
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/bd40067b-41c5-492f-ac9f-bf670740bed1" />

After:
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/3967cd26-2f25-407a-8825-040c815407a0" />
