### PR TITLE
Disable Camera Passthrough for Glass/Iron Bars in <=1.15.x

### DIFF
--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/block/shape/MixinIronBarsBlock.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/block/shape/MixinIronBarsBlock.java
@@ -39,6 +39,7 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(IronBarsBlock.class)
 public abstract class MixinIronBarsBlock extends CrossCollisionBlock implements ICrossCollisionBlock {
@@ -51,6 +52,13 @@ public abstract class MixinIronBarsBlock extends CrossCollisionBlock implements 
 
     protected MixinIronBarsBlock(float radius1, float radius2, float boundingHeight1, float boundingHeight2, float collisionHeight, Properties settings) {
         super(radius1, radius2, boundingHeight1, boundingHeight2, collisionHeight, settings);
+    }
+
+    @Inject(method = "getVisualShape", at = @At("HEAD"), cancellable = true)
+    private void useCollisionVisualShape(BlockState blockState, BlockGetter blockGetter, BlockPos blockPos, CollisionContext collisionContext, CallbackInfoReturnable<VoxelShape> cir) {
+        if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_15_2)) {
+            cir.setReturnValue(this.getCollisionShape(blockState, blockGetter, blockPos, collisionContext));
+        }
     }
 
     @Inject(method = "<init>", at = @At("RETURN"))

--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/block/shape/MixinTransparentBlock.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/block/shape/MixinTransparentBlock.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of ViaFabricPlus - https://github.com/ViaVersion/ViaFabricPlus
+ * Copyright (C) 2021-2025 the original authors
+ *                         - FlorianMichael/EnZaXD <florian.michael07@gmail.com>
+ *                         - RK_01/RaphiMC
+ * Copyright (C) 2023-2025 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.viaversion.viafabricplus.injection.mixin.features.block.shape;
+
+import com.viaversion.viafabricplus.protocoltranslator.ProtocolTranslator;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.HalfTransparentBlock;
+import net.minecraft.world.level.block.TransparentBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(TransparentBlock.class)
+public abstract class MixinTransparentBlock extends HalfTransparentBlock {
+
+    protected MixinTransparentBlock(final Properties properties) {
+        super(properties);
+    }
+
+    @Inject(method = "getVisualShape", at = @At("HEAD"), cancellable = true)
+    private void useCollisionVisualShape(BlockState blockState, BlockGetter blockGetter, BlockPos blockPos, CollisionContext collisionContext, CallbackInfoReturnable<VoxelShape> cir) {
+        if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_15_2)) {
+            cir.setReturnValue(this.getCollisionShape(blockState, blockGetter, blockPos, collisionContext));
+        }
+    }
+
+}

--- a/src/main/resources/viafabricplus.mixins.json
+++ b/src/main/resources/viafabricplus.mixins.json
@@ -97,6 +97,7 @@
     "features.block.shape.MixinPitcherCropBlock",
     "features.block.shape.MixinSnowLayerBlock",
     "features.block.shape.MixinSoulSandBlock",
+    "features.block.shape.MixinTransparentBlock",
     "features.block.shape.MixinWallBlock",
     "features.block.shape.MixinWaterlilyBlock",
     "features.classic.cpe_extension.MixinClassicProtocolExtension",


### PR DESCRIPTION
In <=1.15.x, your camera could not pass through any glass or iron bars, but in 1.16+, it can. This disables that as it's a unfair advantage in situations where you should not be able to do this.