### PR TITLE
Change outline/hitbox fence shape in <=1.12.2

### DIFF
--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/block/shape/MixinFenceBlock.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/block/shape/MixinFenceBlock.java
@@ -47,7 +47,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class MixinFenceBlock extends CrossCollisionBlock implements ICrossCollisionBlock {
 
     @Unique
-    private final VoxelShape[] viaFabricPlus$shapes_r1_12_2 = new VoxelShape[]{
+    private final VoxelShape[] viaFabricPlus$outline_shape_r1_12_2 = new VoxelShape[]{
         Shapes.box(0.375D, 0.0D, 0.375D, 0.625D, 1.0D, 0.625D),
         Shapes.box(0.375D, 0.0D, 0.375D, 0.625D, 1.0D, 1.0D),
         Shapes.box(0.0D, 0.0D, 0.375D, 0.625D, 1.0D, 0.625D),
@@ -67,7 +67,7 @@ public abstract class MixinFenceBlock extends CrossCollisionBlock implements ICr
     };
 
     @Unique
-    private static final VoxelShape viaFabricPlus$shape_b1_8_1 = Block.box(0.0D, 0.0D, 0.0D, 16.0D, 24.0D, 16.0D);
+    private final VoxelShape viaFabricPlus$shape_b1_8_1 = Block.box(0.0D, 0.0D, 0.0D, 16.0D, 24.0D, 16.0D);
 
     @Unique
     private VoxelShape[] viaFabricPlus$collision_shape_r1_4_7;
@@ -101,7 +101,7 @@ public abstract class MixinFenceBlock extends CrossCollisionBlock implements ICr
         } else if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(LegacyProtocolVersion.r1_4_6tor1_4_7)) {
             return this.viaFabricPlus$outline_shape_r1_4_7[this.viaFabricPlus$getShapeIndex(state)];
         } else if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_12_2)) {
-            return this.viaFabricPlus$shapes_r1_12_2[this.viaFabricPlus$getShapeIndex(state)];
+            return this.viaFabricPlus$outline_shape_r1_12_2[this.viaFabricPlus$getShapeIndex(state)];
         } else {
             return super.getShape(state, world, pos, context);
         }


### PR DESCRIPTION
This changes the outline/hitbox shape in <=1.12.2, this doesn't change collision.

This fixes the issue mentioned in the comments of PR #777
<img width="997" height="843" alt="image" src="https://github.com/user-attachments/assets/44b92cb5-7afd-4ad3-8c25-eee4a557eb49" />
