### PR TITLE
Use real knockback value in <=1.20.6

### DIFF
--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/movement/collision/MixinPlayer.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/movement/collision/MixinPlayer.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of ViaFabricPlus - https://github.com/ViaVersion/ViaFabricPlus
+ * Copyright (C) 2021-2025 the original authors
+ *                         - FlorianMichael/EnZaXD <florian.michael07@gmail.com>
+ *                         - RK_01/RaphiMC
+ * Copyright (C) 2023-2025 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.viaversion.viafabricplus.injection.mixin.features.movement.collision;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.viaversion.viafabricplus.protocoltranslator.ProtocolTranslator;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import net.minecraft.world.entity.Avatar;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
+import net.minecraft.world.item.enchantment.Enchantments;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(Player.class)
+public abstract class MixinPlayer extends Avatar {
+
+    protected MixinPlayer(final EntityType<? extends @NotNull LivingEntity> entityType, final Level level) {
+        super(entityType, level);
+    }
+
+    @ModifyExpressionValue(method = "attack", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;getKnockback(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/damagesource/DamageSource;)F"))
+    private float useRealKnockbackValue(float original) {
+        if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_20_5)) {
+            return EnchantmentHelper.getEnchantmentLevel(this.level().registryAccess().getOrThrow(Enchantments.KNOCKBACK), this);
+        } else {
+            return original;
+        }
+    }
+
+}

--- a/src/main/resources/viafabricplus.mixins.json
+++ b/src/main/resources/viafabricplus.mixins.json
@@ -213,6 +213,7 @@
     "features.movement.collision.MixinHoneyBlock",
     "features.movement.collision.MixinLivingEntity",
     "features.movement.collision.MixinLocalPlayer",
+    "features.movement.collision.MixinPlayer",
     "features.movement.collision.MixinShapes",
     "features.movement.collision.MixinSoulSandBlock",
     "features.movement.constants.MixinAvatar",


### PR DESCRIPTION
In versions 1.20.6 and below, the knockback value calculated in Player#attack used the direct enchantment level value, but in 1.21+ it added some extra stuff/checks for the attribute. This was causing flagging. This PR fixes #829 