### PR TITLE
Fix code check (missed in previous pr)

### DIFF
--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/interaction/replace_block_item_use_logic/MixinMultiPlayerGameMode.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/interaction/replace_block_item_use_logic/MixinMultiPlayerGameMode.java
@@ -267,6 +267,11 @@ public abstract class MixinMultiPlayerGameMode {
         return ProtocolTranslator.getTargetVersion().newerThan(ProtocolVersion.v1_7_6) || this.isDestroying;
     }
 
+    @WrapWithCondition(method = "stopDestroyBlock", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;resetAttackStrengthTicker()V"))
+    private boolean preventAttackResetWhenNotMining1_7(LocalPlayer instance) {
+        return ProtocolTranslator.getTargetVersion().newerThan(ProtocolVersion.v1_7_6) || this.isDestroying;
+    }
+
     @Unique
     private boolean viaFabricPlus$extinguishFire(BlockPos blockPos, final Direction direction) {
         blockPos = blockPos.relative(direction);


### PR DESCRIPTION
This fixes a issue of your hand not appearing on screen due to the attack progress being reset to 0, attack progress shouldnt rlly be a issue in <=1.8 but this causes issues w/ other things if called when !this.isMining