### PR TITLE
Disallow hotkeying items in inventory in <1.4.2

### DIFF
--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/interaction/container_clicking/MixinAbstractContainerScreen.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/interaction/container_clicking/MixinAbstractContainerScreen.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of ViaFabricPlus - https://github.com/ViaVersion/ViaFabricPlus
+ * Copyright (C) 2021-2025 the original authors
+ *                         - FlorianMichael/EnZaXD <florian.michael07@gmail.com>
+ *                         - RK_01/RaphiMC
+ * Copyright (C) 2023-2025 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.viaversion.viafabricplus.injection.mixin.features.interaction.container_clicking;
+
+import com.viaversion.viafabricplus.protocoltranslator.ProtocolTranslator;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.client.input.KeyEvent;
+import net.raphimc.vialegacy.api.LegacyProtocolVersion;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(AbstractContainerScreen.class)
+public abstract class MixinAbstractContainerScreen {
+    @Redirect(method = "checkHotbarKeyPressed", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/KeyMapping;matches(Lnet/minecraft/client/input/KeyEvent;)Z", ordinal = 1))
+    private boolean disableInventoryHotkeying(KeyMapping instance, KeyEvent keyEvent) {
+        if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(LegacyProtocolVersion.r1_3_1tor1_3_2)) {
+            return false;
+        } else {
+            return instance.matches(keyEvent);
+        }
+    }
+}

--- a/src/main/resources/viafabricplus.mixins.json
+++ b/src/main/resources/viafabricplus.mixins.json
@@ -152,6 +152,7 @@
     "features.interaction.MixinLivingEntity",
     "features.interaction.MixinPlayer",
     "features.interaction.container_clicking.MixinAbstractContainerMenu",
+    "features.interaction.container_clicking.MixinAbstractContainerScreen",
     "features.interaction.container_clicking.MixinAbstractFurnaceMenu",
     "features.interaction.container_clicking.MixinBlockItemPacketRewriter1_21_5",
     "features.interaction.container_clicking.MixinCraftingMenu",


### PR DESCRIPTION
This prevents you from being able to use your hotkeys (1-9) in your inventory in <1.4 as it didnt exist back then and causes issues.