### PR TITLE
Add visible IP to betacraft server list entries

### DIFF
--- a/src/main/java/com/viaversion/viafabricplus/screen/impl/classic4j/BetaCraftScreen.java
+++ b/src/main/java/com/viaversion/viafabricplus/screen/impl/classic4j/BetaCraftScreen.java
@@ -139,7 +139,10 @@ public final class BetaCraftScreen extends VFPScreen {
             if (server.onlineMode()) {
                 context.drawString(textRenderer, Component.translatable("base.viafabricplus.online_mode").withStyle(ChatFormatting.GREEN), 1, 1, -1);
             }
+            final String serverIP = server.socket();
             final String playerText = server.playerCount() + "/" + server.playerLimit();
+
+            context.drawString(textRenderer, Component.literal(serverIP).withStyle(ChatFormatting.DARK_GRAY), entryWidth - textRenderer.width(serverIP) - 1, entryHeight - textRenderer.lineHeight - 1, -1);
             context.drawString(textRenderer, playerText, entryWidth - textRenderer.width(playerText) - 1, 1, -1);
         }
     }


### PR DESCRIPTION
As an administrator for one of the servers visible on the Betacraft server list, I have noticed that some people were asking me for the server IP in-game after joining our server. When i asked how they joined the server without seeing it they replied they were using ViaFabricPlus' Betacraft server list view, so i decided to make a PR adding this functionality.
<img width="794" height="958" alt="image" src="https://github.com/user-attachments/assets/c83fd9b2-2923-486e-8fb3-c4cadbd18b83" />