### PR TITLE
Fix birch and spruce log mining speed between b1.2 (initial version with birch and spruce) and b1.8.1

### DIFF
--- a/src/main/resources/assets/viafabricplus/data/item-tool-components.json
+++ b/src/main/resources/assets/viafabricplus/data/item-tool-components.json
@@ -11,7 +11,9 @@
             "minecraft:bookshelf",
             "minecraft:chest",
             "minecraft:oak_planks",
-            "minecraft:oak_log"
+            "minecraft:oak_log",
+            "minecraft:birch_log",
+            "minecraft:spruce_log"
           ],
           "speed": 2.0
         }
@@ -28,7 +30,9 @@
             "minecraft:bookshelf",
             "minecraft:chest",
             "minecraft:oak_planks",
-            "minecraft:oak_log"
+            "minecraft:oak_log",
+            "minecraft:birch_log",
+            "minecraft:spruce_log"
           ],
           "speed": 4.0
         }
@@ -45,7 +49,9 @@
             "minecraft:bookshelf",
             "minecraft:chest",
             "minecraft:oak_planks",
-            "minecraft:oak_log"
+            "minecraft:oak_log",
+            "minecraft:birch_log",
+            "minecraft:spruce_log"
           ],
           "speed": 6.0
         }
@@ -62,7 +68,9 @@
             "minecraft:bookshelf",
             "minecraft:chest",
             "minecraft:oak_planks",
-            "minecraft:oak_log"
+            "minecraft:oak_log",
+            "minecraft:birch_log",
+            "minecraft:spruce_log"
           ],
           "speed": 12.0
         }
@@ -79,7 +87,9 @@
             "minecraft:bookshelf",
             "minecraft:chest",
             "minecraft:oak_planks",
-            "minecraft:oak_log"
+            "minecraft:oak_log",
+            "minecraft:birch_log",
+            "minecraft:spruce_log"
           ],
           "speed": 8.0
         }


### PR DESCRIPTION
As seen in the example below (the video in question was recorded in b1.7.3, but from my observations any version between b1.2 and b1.8.1 has the same behavior) the log mining speed with axes in vanilla Minecraft is identical between log types, however ViaFabricPlus would mine birch and spruce logs with axes with the hand mining speed before this PR.

https://github.com/user-attachments/assets/ef244f05-2e8c-4a2b-b07e-d5fd05fbb09d

