### PR TITLE
Fix submerged eye height offset in <=1.15.2

### DIFF
--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/movement/liquid/MixinEntity.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/movement/liquid/MixinEntity.java
@@ -63,7 +63,7 @@ public abstract class MixinEntity {
     public abstract void setDeltaMovement(Vec3 velocity);
 
     @Redirect(method = "updateFluidOnEyes", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;getEyeY()D"))
-    private double addMagicOffset(Entity instance) {
+    private double subtractMagicOffset(Entity instance) {
         if (ProtocolTranslator.getTargetVersion().betweenInclusive(ProtocolVersion.v1_16, ProtocolVersion.v1_20_3)) {
             return instance.getEyeY() - 0.11111111F;
         } else {
@@ -72,7 +72,7 @@ public abstract class MixinEntity {
     }
 
     @Redirect(method = "updateFluidOnEyes", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/material/FluidState;getHeight(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)F"))
-    private float subtractMagicOffset(FluidState instance, BlockGetter blockGetter, BlockPos blockPos) {
+    private float addMagicOffset(FluidState instance, BlockGetter blockGetter, BlockPos blockPos) {
         if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_15_2)) {
             return instance.getHeight(blockGetter, blockPos) + 0.11111111F;
         } else {


### PR DESCRIPTION
Fixes wrong version range for magic offset and fixes offset for <=1.15.2, which fixes:
https://github.com/ViaVersion/ViaFabricPlus/issues/996