### PR TITLE
Create Security document for reporting private issues

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a **security vulnerability**, please **do not** open a public issue. Instead, use one of the following **confidential contact methods**:
+
+* **Email:** [florian@florianreuth.de](mailto:florian@florianreuth.de)
+* **Discord Username:** `florianreuth`
+
+If your issue is **not security-related** (e.g., bug reports, feature requests, or usage questions), please use the [GitHub Issues page](https://github.com/ViaVersion/ViaFabricPlus/issues) or contact us via the [Discord server](https://discord.gg/viaversion).


### PR DESCRIPTION
Adds security document for reporting private issues in terms of ViaFabricPlus in general,
Resolves GitHub's security section via community standards checklist which is currently 4 out of 8.