### PR TITLE
"alpha" <- "beta" in bedrock section

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -87,7 +87,7 @@ It shows useful connection and protocol info while playing.
 
 ViaFabricPlus also lets you connect to **Bedrock servers** – but keep in mind:
 
-- Support is still **beta**
+- Support is still **alpha**
 - Many features are incomplete or may not work correctly
 
 To log into a Bedrock account:


### PR DESCRIPTION
Given bedrock support is currently very broken, it should be considered as alpha stage instead as it isn't feature-complete yet.