### PR TITLE
Update dependencies for 1.21.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,3 +28,4 @@ jobs:
         with:
           name: Artifacts
           path: build/libs/
+          if-no-files-found: error

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
     configureBedrockDependencies()
 
     testImplementation("net.fabricmc:fabric-loader-junit:${property("fabric_loader_version")}")
-    modCompileOnly("com.terraformersmc:modmenu:16.0.0")
+    modCompileOnly("com.terraformersmc:modmenu:17.0.0")
 }
 
 includeTransitiveJijDependencies()
@@ -77,8 +77,8 @@ fun configureBedrockDependencies() {
 
 fun Project.configureVVDependencies(configuration: String) {
     dependencies {
-        configuration("com.viaversion:viaversion-common:5.8.0")
-        configuration("com.viaversion:viabackwards-common:5.8.0")
+        configuration("com.viaversion:viaversion-common:5.8.1-SNAPSHOT")
+        configuration("com.viaversion:viabackwards-common:5.8.1-SNAPSHOT")
         configuration("com.viaversion:viaaprilfools-common:4.1.0")
         configuration("net.raphimc:ViaLegacy:3.0.14")
         configuration("net.raphimc:ViaBedrock:0.0.26-20260327.164936-8") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,8 +77,8 @@ fun configureBedrockDependencies() {
 
 fun Project.configureVVDependencies(configuration: String) {
     dependencies {
-        configuration("com.viaversion:viaversion-common:5.8.1-SNAPSHOT")
-        configuration("com.viaversion:viabackwards-common:5.8.1-SNAPSHOT")
+        configuration("com.viaversion:viaversion-common:5.8.1")
+        configuration("com.viaversion:viabackwards-common:5.8.1")
         configuration("com.viaversion:viaaprilfools-common:4.1.0")
         configuration("net.raphimc:ViaLegacy:3.0.14")
         configuration("net.raphimc:ViaBedrock:0.0.26-20260327.164936-8") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ project_jvm_version=21
 
 project_group=com.viaversion
 project_name=ViaFabricPlus
-project_version=4.4.9
+project_version=4.4.10-SNAPSHOT
 project_description=Minecraft Fabric mod which allows you to join EVERY Minecraft server version (Classic, Alpha, Beta, Release, April Fools, Bedrock)
 
 publishing_dev_id=florianreuth
@@ -15,8 +15,8 @@ publishing_dev_name=Florian Reuth
 publishing_dev_mail=git@florianreuth.de
 
 minecraft_version=1.21.11
-fabric_loader_version=0.18.4
-fabric_api_version=0.141.2+1.21.11
+fabric_loader_version=0.18.5
+fabric_api_version=0.141.3+1.21.11
 
 # Allows running of `gradle test` - disable after running
 updating_minecraft=false

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {
 
     plugins {
         id("net.fabricmc.fabric-loom-remap") version "1.15-SNAPSHOT"
-        id("de.florianreuth.baseproject") version "2.0.1"
+        id("de.florianreuth.baseproject") version "2.0.2"
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {
 
     plugins {
         id("net.fabricmc.fabric-loom-remap") version "1.15-SNAPSHOT"
-        id("de.florianreuth.baseproject") version "2.0.2"
+        id("de.florianreuth.baseproject") version "2.0.1"
     }
 }
 


### PR DESCRIPTION
Enters ViaFabricPlus 1.21.11 into `4.4.10-SNAPSHOT` to address important issues like `RECIPE_BOOK_ADD` packet failing. ViaBedrock has not been bumped in case it depends on 26.1.