### PR TITLE
VV 5.9.0-SNAPSHOT for 1.21.11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,10 +77,10 @@ fun configureBedrockDependencies() {
 
 fun Project.configureVVDependencies(configuration: String) {
     dependencies {
-        configuration("com.viaversion:viaversion-common:5.8.1")
-        configuration("com.viaversion:viabackwards-common:5.8.1")
-        configuration("com.viaversion:viaaprilfools-common:4.1.0")
-        configuration("net.raphimc:ViaLegacy:3.0.14")
+        configuration("com.viaversion:viaversion-common:5.9.0-SNAPSHOT")
+        configuration("com.viaversion:viabackwards-common:5.9.0-SNAPSHOT")
+        configuration("com.viaversion:viaaprilfools-common:4.2.0-SNAPSHOT")
+        configuration("net.raphimc:ViaLegacy:3.0.15-SNAPSHOT")
         configuration("net.raphimc:ViaBedrock:0.0.27-20260329.200308-2") {
             exclude(group = "com.mojang", module = "brigadier")
             exclude(group = "at.yawk.lz4", module = "lz4-java")

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ project_jvm_version=21
 
 project_group=com.viaversion
 project_name=ViaFabricPlus
-project_version=4.4.10
+project_version=4.4.11-SNAPSHOT
 project_description=Minecraft Fabric mod which allows you to join EVERY Minecraft server version (Classic, Alpha, Beta, Release, April Fools, Bedrock)
 
 publishing_dev_id=florianreuth
@@ -15,7 +15,7 @@ publishing_dev_name=Florian Reuth
 publishing_dev_mail=git@florianreuth.de
 
 minecraft_version=1.21.11
-fabric_loader_version=0.18.5
+fabric_loader_version=0.18.6
 fabric_api_version=0.141.3+1.21.11
 
 # Allows running of `gradle test` - disable after running


### PR DESCRIPTION
Mainly done to address additional bugs and because 26.1.1 = 26.1,
Crafting recipe results in 1.11.2 and older was not backported in this version because i don't know how to do that myself and translation files were left as they are.