### PR TITLE
fix(MixinMouseHandler): adjust for <1.9 sensitivity calculations

### DIFF
--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/mouse_sensitivity/MixinMouseHandler.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/mouse_sensitivity/MixinMouseHandler.java
@@ -26,14 +26,15 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.viaversion.viafabricplus.features.mouse_sensitivity.MouseSensitivity1_13_2;
 import com.viaversion.viafabricplus.protocoltranslator.ProtocolTranslator;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.MouseHandler;
 import net.minecraft.client.OptionInstance;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(MouseHandler.class)
 public abstract class MixinMouseHandler {
-
     @WrapOperation(method = "turnPlayer", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/OptionInstance;get()Ljava/lang/Object;", ordinal = 0))
     private Object adjustMouseSensitivity1_13_2(OptionInstance<Double> instance, Operation<Double> original) {
         final Double value = original.call(instance);
@@ -44,5 +45,11 @@ public abstract class MixinMouseHandler {
             return value;
         }
     }
+    @ModifyVariable(method = "turnPlayer", at = @At("STORE"), ordinal = 3)
+    private double adjustSensitivity1_8(double sens) {
+        if (ProtocolTranslator.getTargetVersion().newerThanOrEqualTo(ProtocolVersion.v1_9)) return sens;
+        final var ss = Minecraft.getInstance().options.sensitivity().get().floatValue() * 0.6F + 0.2F;
 
+        return ss * ss * ss * 8.0F;
+    }
 }


### PR DESCRIPTION
26.1:
```java
double ss = (Double)this.minecraft.options.sensitivity().get() * (double)0.6F + (double)0.2F;
double sensitivityMod = ss * ss * ss;
double sens = sensitivityMod * (double)8.0F;
```
[1.8.9](https://github.com/Marcelektro/MCP-919/blob/1717f75902c6184a1ed1bfcd7880404aab4da503/src/minecraft/net/minecraft/client/renderer/EntityRenderer.java#L1097-L1098):
```java
float ss = mc.gameSettings.mouseSensitivity * 0.6F + 0.2F;
float sensitivityMod = ss * ss * ss;
float sens = sensitivityMod * 8.0F;
```

they're structurally the same, but the 1.8.9 one uses `float` instead of `double`.

Related to https://github.com/CCBlueX/LiquidBounce/issues/8103, ~~may even fix it if aimbot actually uses mouse inputs (never did anything with aimbot because I don't ghost cheat so...)~~.
This seems to be enough to stop flagging on some random ac, but I never tested Vulcan without the fix so idk.
I haven't done anything with ViaFabricPlus before other than like using its API in my own client, so I basically know little to nothing here.

> [!IMPORTANT]
>
> <img width="3024" height="4032" alt="Kitten on roof" src="https://github.com/user-attachments/assets/f4b4d87e-bca4-4bc4-a85b-0e3eca7f8549" />
