### PR TITLE
fix: intercept DecoderException in Connection.exceptionCaught to respect ignorePacketTranslationErrors

### DIFF
--- a/src/main/java/com/viaversion/viafabricplus/features/item/r1_14_4_enchantment_tooltip/Enchantments1_14_4.java
+++ b/src/main/java/com/viaversion/viafabricplus/features/item/r1_14_4_enchantment_tooltip/Enchantments1_14_4.java
@@ -71,6 +71,10 @@ public final class Enchantments1_14_4 {
         ENCHANTMENT_REGISTRY.put("piercing", Enchantments.PIERCING);
         ENCHANTMENT_REGISTRY.put("mending", Enchantments.MENDING);
         ENCHANTMENT_REGISTRY.put("vanishing_curse", Enchantments.VANISHING_CURSE);
+        // Minecraft 1.21 Mace enchantments
+        ENCHANTMENT_REGISTRY.put("density", Enchantments.DENSITY);
+        ENCHANTMENT_REGISTRY.put("breach", Enchantments.BREACH);
+        ENCHANTMENT_REGISTRY.put("wind_burst", Enchantments.WIND_BURST);
     }
 
     public static Optional<ResourceKey<Enchantment>> getOrEmpty(final String identifier) {

--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/core/integration/MixinConnection.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/core/integration/MixinConnection.java
@@ -23,13 +23,18 @@ package com.viaversion.viafabricplus.injection.mixin.core.integration;
 
 import com.viaversion.viafabricplus.ViaFabricPlusImpl;
 import com.viaversion.viafabricplus.settings.impl.DebugSettings;
+import com.viaversion.viafabricplus.settings.impl.GeneralSettings;
+import com.viaversion.viafabricplus.util.ChatUtil;
 import com.viaversion.viaversion.platform.ViaChannelInitializer;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.DecoderException;
 import java.net.ConnectException;
 import java.net.SocketException;
 import io.netty.channel.SimpleChannelInboundHandler;
+import net.minecraft.ChatFormatting;
 import net.minecraft.network.Connection;
 import net.minecraft.network.HandlerNames;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.Packet;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -39,7 +44,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(Connection.class)
 public abstract class MixinConnection extends SimpleChannelInboundHandler<Packet<?>> {
 
-    @Inject(method = "exceptionCaught", at = @At("HEAD"))
+    @Inject(method = "exceptionCaught", at = @At("HEAD"), cancellable = true)
     private void printNetworkingErrors(ChannelHandlerContext context, Throwable ex, CallbackInfo ci) {
         if (DebugSettings.INSTANCE.printNetworkingErrorsToLogs.getValue()) {
             if (ex instanceof SocketException || ex instanceof ConnectException) {
@@ -47,6 +52,24 @@ public abstract class MixinConnection extends SimpleChannelInboundHandler<Packet
                 return;
             }
             ViaFabricPlusImpl.INSTANCE.getLogger().error("An exception occurred while handling a packet", ex);
+        }
+
+        // When ignorePacketTranslationErrors is enabled, swallow DecoderExceptions
+        // to prevent the client from being disconnected. The exception originates from
+        // ByteToMessageDecoder which catches it internally and fires exceptionCaught
+        // on the pipeline — it never reaches ViaFabricPlusDecoder's catch block.
+        if (ex instanceof DecoderException) {
+            final int mode = GeneralSettings.INSTANCE.ignorePacketTranslationErrors.getIndex();
+            if (mode > 0) {
+                ViaFabricPlusImpl.INSTANCE.getLogger().error("ViaFabricPlus ignored a packet translation error", ex);
+                if (mode == 1) {
+                    ChatUtil.sendPrefixedMessage(
+                            Component.translatable("translation.viafabricplus.packet_error")
+                                    .withStyle(ChatFormatting.RED)
+                    );
+                }
+                ci.cancel();
+            }
         }
     }
 

--- a/src/main/java/com/viaversion/viafabricplus/protocoltranslator/netty/ViaFabricPlusDecoder.java
+++ b/src/main/java/com/viaversion/viafabricplus/protocoltranslator/netty/ViaFabricPlusDecoder.java
@@ -23,6 +23,7 @@ package com.viaversion.viafabricplus.protocoltranslator.netty;
 
 import com.viaversion.viafabricplus.ViaFabricPlusImpl;
 import com.viaversion.viafabricplus.settings.impl.GeneralSettings;
+import io.netty.handler.codec.DecoderException;
 import com.viaversion.viafabricplus.util.ChatUtil;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.exception.CancelCodecException;
@@ -35,6 +36,24 @@ public final class ViaFabricPlusDecoder extends ViaDecodeHandler {
 
     public ViaFabricPlusDecoder(UserConnection connection) {
         super(connection);
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        if (cause instanceof DecoderException) {
+            final int mode = GeneralSettings.INSTANCE.ignorePacketTranslationErrors.getIndex();
+            if (mode > 0) {
+                ViaFabricPlusImpl.INSTANCE.getLogger().error("ViaFabricPlus ignored a packet translation error", cause);
+                if (mode == 1) {
+                    ChatUtil.sendPrefixedMessage(
+                            Component.translatable("translation.viafabricplus.packet_error")
+                                    .withStyle(ChatFormatting.RED)
+                    );
+                }
+                return;
+            }
+        }
+        super.exceptionCaught(ctx, cause);
     }
 
     @Override


### PR DESCRIPTION
## Description

Fixes #1169 - Kick when player gets killed using unknown enchantment

### Root Cause Analysis

The exception propagates through ByteToMessageDecoder which catches DecoderException internally and re-dispatches via exceptionCaught - never reaching ViaFabricPlusDecoder try-catch.

### Changes

**1. MixinConnection.java** - Made exceptionCaught cancellable; intercept DecoderException when ignorePacketTranslationErrors > 0, swallow via ci.cancel()

**2. Enchantments1_14_4.java** - Added density, breach, wind_burst

### Previous Attempt
Replaces #1170 which incorrectly fixed in ViaFabricPlusDecoder catch block (ineffective)