### PR TITLE
Add @FunctionalInterface annotation to IPlayerInfo interface

### DIFF
--- a/viafabricplus-visuals/src/main/java/com/viaversion/viafabricplus/visuals/injection/access/r1_7_tab_list_tyle/IPlayerInfo.java
+++ b/viafabricplus-visuals/src/main/java/com/viaversion/viafabricplus/visuals/injection/access/r1_7_tab_list_tyle/IPlayerInfo.java
@@ -21,6 +21,7 @@
 
 package com.viaversion.viafabricplus.visuals.injection.access.r1_7_tab_list_tyle;
 
+@FunctionalInterface
 public interface IPlayerInfo {
 
     int viaFabricPlusVisuals$getIndex();


### PR DESCRIPTION
### Background
The `IPlayerInfo` interface currently has only one abstract method (`viaFabricPlusVisuals$getIndex()`) but is not explicitly marked as a functional interface. This omission can reduce code readability and intent clarity, potentially leading other developers to mistakenly assume that additional abstract methods can be added without breaking functionality.

### Changes
- Added the `@FunctionalInterface` annotation to the `IPlayerInfo` interface to clearly designate it as a functional interface, aligning with Java best practices and enhancing code documentation.

### Verification
This change is minimal and does not alter the interface's runtime behavior or public API. It can be verified by ensuring the project compiles successfully with the annotation in place, as the annotation only enforces compile-time checks for functional interfaces.