### PR TITLE
Unload lithium sin/cos optimization (for 1.21.11)

### DIFF
--- a/src/main/java/com/viaversion/viafabricplus/features/movement/elytra/LithiumWorkaround.java
+++ b/src/main/java/com/viaversion/viafabricplus/features/movement/elytra/LithiumWorkaround.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of ViaFabricPlus - https://github.com/ViaVersion/ViaFabricPlus
+ * Copyright (C) 2021-2026 the original authors
+ *                         - Florian Reuth <git@florianreuth.de>
+ *                         - RK_01/RaphiMC
+ * Copyright (C) 2023-2026 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.viaversion.viafabricplus.features.movement.constants;
+
+import net.lenni0451.reflect.stream.RStream;
+import java.util.Set;
+
+public final class LithiumWorkaround {
+
+    public static void init() {
+        // Workaround for https://github.com/ViaVersion/ViaFabricPlus/issues/1206 where lithium replaces sin/cos lookups using an optimized version
+        final Set<String> loadedMixins = RStream.of("org.spongepowered.asm.mixin.transformer.MixinConfig").fields().by("globalMixinList").get();
+        loadedMixins.add("net.caffeinemc.mods.lithium.mixin.math.sine_lut.MthMixin");
+    }
+
+}

--- a/src/main/java/com/viaversion/viafabricplus/injection/ViaFabricPlusMixinPlugin.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/ViaFabricPlusMixinPlugin.java
@@ -21,6 +21,7 @@
 
 package com.viaversion.viafabricplus.injection;
 
+import com.viaversion.viafabricplus.features.movement.constants.LithiumWorkaround;
 import com.viaversion.viafabricplus.features.movement.elytra.FabricAPIWorkaround;
 import java.util.List;
 import java.util.Set;
@@ -52,6 +53,7 @@ public final class ViaFabricPlusMixinPlugin implements IMixinConfigPlugin {
         LEGACY_PRESENT = loader.isModLoaded("legacy");
 
         FabricAPIWorkaround.init();
+        LithiumWorkaround.init();
     }
 
     @Override


### PR DESCRIPTION
Force-disables the sin/cos optimization from Lithium for 1.21.11 branch as this version is affected.