### PR TITLE
Revert entity distance scaling in <=1.15

### DIFF
--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/world/entity_distance/MixinClientLevel.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/world/entity_distance/MixinClientLevel.java
@@ -19,9 +19,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.viaversion.viafabricplus.injection.mixin.features.world.particle_distance;
+package com.viaversion.viafabricplus.injection.mixin.features.world.entity_distance;
 
-import com.viaversion.viafabricplus.settings.impl.DebugSettings;
+import com.viaversion.viafabricplus.protocoltranslator.ProtocolTranslator;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import net.minecraft.client.multiplayer.ClientLevel;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Constant;
@@ -32,7 +33,7 @@ public abstract class MixinClientLevel {
 
     @ModifyConstant(method = "doAddParticle", constant = @Constant(doubleValue = 1024.0))
     private double lowerParticleRenderDistance(double constant) {
-        if (DebugSettings.INSTANCE.lowerParticleRenderDistance.isEnabled()) {
+        if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_8)) {
             return 256.0;
         } else {
             return constant;

--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/world/entity_distance/MixinLevelExtractor.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/world/entity_distance/MixinLevelExtractor.java
@@ -21,26 +21,24 @@
 
 package com.viaversion.viafabricplus.injection.mixin.features.world.entity_distance;
 
-import com.llamalad7.mixinextras.expression.Definition;
-import com.llamalad7.mixinextras.expression.Expression;
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.viaversion.viafabricplus.protocoltranslator.ProtocolTranslator;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import net.minecraft.client.OptionInstance;
 import net.minecraft.client.renderer.extract.LevelExtractor;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Coerce;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(LevelExtractor.class)
 public abstract class MixinLevelExtractor {
 
-    @Definition(id = "setViewScale", method = "Lnet/minecraft/world/entity/Entity;setViewScale(D)V")
-    @Expression("setViewScale(? * @(?))")
-    @ModifyExpressionValue(method = "extractVisibleEntities", at = @At("MIXINEXTRAS:EXPRESSION"))
-    private Double removeDistanceScaling(final Double original) {
+    @Redirect(method = "extractVisibleEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/OptionInstance;get()Ljava/lang/Object;"))
+    private @Coerce Object removeDistanceScaling(OptionInstance<Double> instance) {
         if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_15_2)) {
             return 1.0D;
         } else {
-            return original;
+            return instance.get();
         }
     }
 

--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/world/entity_distance/MixinLevelExtractor.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/world/entity_distance/MixinLevelExtractor.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of ViaFabricPlus - https://github.com/ViaVersion/ViaFabricPlus
+ * Copyright (C) 2021-2026 the original authors
+ *                         - Florian Reuth <git@florianreuth.de>
+ *                         - RK_01/RaphiMC
+ * Copyright (C) 2023-2026 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.viaversion.viafabricplus.injection.mixin.features.world.entity_distance;
+
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.viaversion.viafabricplus.protocoltranslator.ProtocolTranslator;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import net.minecraft.client.renderer.extract.LevelExtractor;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(LevelExtractor.class)
+public abstract class MixinLevelExtractor {
+
+    @Definition(id = "setViewScale", method = "Lnet/minecraft/world/entity/Entity;setViewScale(D)V")
+    @Expression("setViewScale(? * @(?))")
+    @ModifyExpressionValue(method = "extractVisibleEntities", at = @At("MIXINEXTRAS:EXPRESSION"))
+    private Double removeDistanceScaling(final Double original) {
+        if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_15_2)) {
+            return 1.0D;
+        } else {
+            return original;
+        }
+    }
+
+}

--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/world/entity_distance/MixinRemotePlayer.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/world/entity_distance/MixinRemotePlayer.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of ViaFabricPlus - https://github.com/ViaVersion/ViaFabricPlus
+ * Copyright (C) 2021-2026 the original authors
+ *                         - Florian Reuth <git@florianreuth.de>
+ *                         - RK_01/RaphiMC
+ * Copyright (C) 2023-2026 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.viaversion.viafabricplus.injection.mixin.features.world.entity_distance;
+
+import com.mojang.authlib.GameProfile;
+import com.viaversion.viafabricplus.protocoltranslator.ProtocolTranslator;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.client.player.RemotePlayer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(RemotePlayer.class)
+public abstract class MixinRemotePlayer extends AbstractClientPlayer {
+
+    public MixinRemotePlayer(final ClientLevel level, final GameProfile gameProfile) {
+        super(level, gameProfile);
+    }
+
+    @Inject(method = "shouldRenderAtSqrDistance", at = @At("HEAD"), cancellable = true)
+    private void useSuperDistance(final double distance, final CallbackInfoReturnable<Boolean> cir) {
+        if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_8)) {
+            cir.setReturnValue(super.shouldRenderAtSqrDistance(distance));
+        }
+    }
+
+}

--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/world/entity_distance/MixinRemotePlayer.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/world/entity_distance/MixinRemotePlayer.java
@@ -40,7 +40,7 @@ public abstract class MixinRemotePlayer extends AbstractClientPlayer {
     }
 
     @Inject(method = "shouldRenderAtSqrDistance", at = @At("HEAD"), cancellable = true)
-    private void useSuperDistance(final double distance, final CallbackInfoReturnable<Boolean> cir) {
+    private void revert10thMultiplication(final double distance, final CallbackInfoReturnable<Boolean> cir) {
         if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_8)) {
             cir.setReturnValue(super.shouldRenderAtSqrDistance(distance));
         }

--- a/src/main/java/com/viaversion/viafabricplus/settings/impl/DebugSettings.java
+++ b/src/main/java/com/viaversion/viafabricplus/settings/impl/DebugSettings.java
@@ -67,7 +67,6 @@ public final class DebugSettings extends SettingGroup {
     public final VersionedBooleanSetting hideModernCommandBlockScreenFeatures = new VersionedBooleanSetting(this, Component.translatable("debug_settings.viafabricplus.hide_modern_command_block_screen_features"), ProtocolVersionRange.andOlder(ProtocolVersion.v1_8));
     public final VersionedBooleanSetting legacyCropOutlines = new VersionedBooleanSetting(this, Component.translatable("debug_settings.viafabricplus.legacy_crop_outlines"), ProtocolVersionRange.andOlder(ProtocolVersion.v1_8));
     public final VersionedBooleanSetting serversidePlaceSounds = new VersionedBooleanSetting(this, Component.translatable("debug_settings.viafabricplus.serverside_place_sounds"), ProtocolVersionRange.andOlder(ProtocolVersion.v1_8));
-    public final VersionedBooleanSetting lowerParticleRenderDistance = new VersionedBooleanSetting(this, Component.translatable("debug_settings.viafabricplus.lower_particle_render_distance"), ProtocolVersionRange.andOlder(ProtocolVersion.v1_8));
 
     // b1.8/b1.8.1 -> b1_7/b1.7.3
     public final VersionedBooleanSetting disableServerPinging = new VersionedBooleanSetting(this, Component.translatable("debug_settings.viafabricplus.disable_server_pinging"), ProtocolVersionRange.andOlder(LegacyProtocolVersion.b1_7tob1_7_3));

--- a/src/main/resources/assets/viafabricplus/lang/en_us.json
+++ b/src/main/resources/assets/viafabricplus/lang/en_us.json
@@ -83,7 +83,6 @@
   "debug_settings.viafabricplus.legacy_pane_outlines": "Legacy pane outlines",
   "debug_settings.viafabricplus.serverside_place_sounds": "Serverside block/item place sounds",
   "debug_settings.viafabricplus.remove_server_description_sanitize": "Remove server description sanitize",
-  "debug_settings.viafabricplus.lower_particle_render_distance": "Lower particle render distance",
 
   "authentication_settings.viafabricplus.use_beta_craft_authentication": "Use BetaCraft authentication",
   "authentication_settings.viafabricplus.verify_session_for_online_mode": "Verify session for online mode servers",

--- a/src/main/resources/viafabricplus.mixins.json
+++ b/src/main/resources/viafabricplus.mixins.json
@@ -365,14 +365,14 @@
     "features.world.duplicated_sounds.MixinBlockItem",
     "features.world.duplicated_sounds.MixinButtonBlock",
     "features.world.duplicated_sounds.MixinItems",
+    "features.world.entity_distance.MixinClientLevel",
+    "features.world.entity_distance.MixinLevelExtractor",
+    "features.world.entity_distance.MixinRemotePlayer",
     "features.world.footstep_particle.MixinMappingDataBase",
     "features.world.footstep_particle.MixinParticleIdMappings1_13",
     "features.world.footstep_particle.MixinParticleMappings",
     "features.world.footstep_particle.MixinRegistrySyncManager",
     "features.world.item_picking.MixinMinecraft",
-    "features.world.entity_distance.MixinClientLevel",
-    "features.world.entity_distance.MixinLevelExtractor",
-    "features.world.entity_distance.MixinRemotePlayer",
     "features.world.remove_server_view_distance.MixinOptions"
   ],
   "injectors": {

--- a/src/main/resources/viafabricplus.mixins.json
+++ b/src/main/resources/viafabricplus.mixins.json
@@ -370,7 +370,9 @@
     "features.world.footstep_particle.MixinParticleMappings",
     "features.world.footstep_particle.MixinRegistrySyncManager",
     "features.world.item_picking.MixinMinecraft",
-    "features.world.particle_distance.MixinClientLevel",
+    "features.world.entity_distance.MixinClientLevel",
+    "features.world.entity_distance.MixinLevelExtractor",
+    "features.world.entity_distance.MixinRemotePlayer",
     "features.world.remove_server_view_distance.MixinOptions"
   ],
   "injectors": {


### PR DESCRIPTION
Removes entity distance scaling setting in <=1.15 

Makes RemotePlayer use base shouldRenderAtSqrDistance in <=1.8

Remove setting for particle distance as discussed.