### PR TITLE
Fix incorrect version range for horizontalExactCollisionEqualness

### DIFF
--- a/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/movement/collision/MixinEntity.java
+++ b/src/main/java/com/viaversion/viafabricplus/injection/mixin/features/movement/collision/MixinEntity.java
@@ -190,7 +190,7 @@ public abstract class MixinEntity {
 
     @Redirect(method = "move", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Mth;equal(DD)Z"))
     private static boolean horizontalExactCollisionEqualness(double a, double b) {
-        if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_12_2)) {
+        if (ProtocolTranslator.getTargetVersion().olderThanOrEqualTo(ProtocolVersion.v1_13_2)) {
             return a == b;
         } else {
             return Mth.equal(a, b);


### PR DESCRIPTION
It affects <=1.13.2, not <=1.12.2